### PR TITLE
bugfix: Working stderr!

### DIFF
--- a/webui/js/ActionButton.js
+++ b/webui/js/ActionButton.js
@@ -15,7 +15,7 @@ class ActionButton extends window.HTMLElement {
     this.updateFromJson(json)
 
     // DOM Attributes
-    this.setAttribute("role", "none")
+    this.setAttribute('role', 'none')
     this.btn.title = json.title
     this.btn.onclick = () => {
       console.log(json.arguments)


### PR DESCRIPTION
Was experimenting with executing commands without using a shell (`sh -c`), but found that we didn't need to drop the shell support to get stderr working properly. Had been assigning stderr completely wrong until now!