### PR TITLE
Created a service file for OpenRC (Alpine Linux/Gentoo)

### DIFF
--- a/openrc-OliveTin
+++ b/openrc-OliveTin
@@ -1,0 +1,7 @@
+#!/sbin/openrc-run
+
+name=$RC_SVCNAME
+description="OliveTin"
+command="/usr/local/bin/OliveTin"
+pidfile="/run/${RC_SVCNAME}.pid"
+command_background=true


### PR DESCRIPTION
This service file should really just be called "OliveTin" when installing, but I've named it `openrc-OliveTin` for convenience at the moment. Basically, if you follow the usual manual installation guide, substituting this file for `OliveTin.service` and putting it in `/etc/init.d/` will work just fine.

(Though it has to be made executable, it isn't at present)

The service can be enabled on boot with `rc-update add OliveTin`, and started/stopped with `service OliveTin start/stop`. I have tested this on Alpine Linux, but it *should* also work on Gentoo and any other openRC-based system.