### PR TITLE
feature: sosreport

### DIFF
--- a/OliveTin.proto
+++ b/OliveTin.proto
@@ -93,6 +93,12 @@ message WhoAmIResponse {
 	string authenticatedUser = 1;
 }
 
+message SosReportRequest {}
+
+message SosReportResponse {
+	string alert = 1;
+}
+
 service OliveTinApi {
 	rpc GetDashboardComponents(GetDashboardComponentsRequest) returns (GetDashboardComponentsResponse) {
 		option (google.api.http) = {
@@ -123,6 +129,12 @@ service OliveTinApi {
 	rpc WhoAmI(WhoAmIRequest) returns (WhoAmIResponse) {
 		option (google.api.http) = {
 			get: "/api/WhoAmI"
+		};
+	}
+
+	rpc SosReport(SosReportRequest) returns (SosReportResponse) {
+		option (google.api.http) = {
+			get: "/api/sosreport"
 		};
 	}
 }

--- a/cmd/OliveTin/main.go
+++ b/cmd/OliveTin/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/OliveTin/OliveTin/internal/executor"
 	grpcapi "github.com/OliveTin/OliveTin/internal/grpcapi"
+	"github.com/OliveTin/OliveTin/internal/installationinfo"
 	"github.com/OliveTin/OliveTin/internal/oncron"
 	"github.com/OliveTin/OliveTin/internal/onstartup"
 	updatecheck "github.com/OliveTin/OliveTin/internal/updatecheck"
@@ -75,6 +76,11 @@ func init() {
 	reloadConfig()
 
 	warnIfPuidGuid()
+
+	installationinfo.Config = cfg
+	installationinfo.Build.Version = version
+	installationinfo.Build.Commit = commit
+	installationinfo.Build.Date = date
 
 	log.Info("Init complete")
 }

--- a/internal/grpcapi/grpcApi.go
+++ b/internal/grpcapi/grpcApi.go
@@ -11,6 +11,7 @@ import (
 	acl "github.com/OliveTin/OliveTin/internal/acl"
 	config "github.com/OliveTin/OliveTin/internal/config"
 	executor "github.com/OliveTin/OliveTin/internal/executor"
+	installationinfo "github.com/OliveTin/OliveTin/internal/installationinfo"
 )
 
 var (
@@ -104,6 +105,16 @@ func (api *oliveTinAPI) WhoAmI(ctx ctx.Context, req *pb.WhoAmIRequest) (*pb.WhoA
 	}
 
 	log.Warnf("usergroup: %v", user.Usergroup)
+
+	return res, nil
+}
+
+func (api *oliveTinAPI) SosReport(ctx ctx.Context, req *pb.SosReportRequest) (*pb.SosReportResponse, error) {
+	res := &pb.SosReportResponse{
+		Alert: "Your SOS Report has been logged to OliveTin logs.",
+	}
+
+	log.Infof("\n" + installationinfo.GetSosReport())
 
 	return res, nil
 }

--- a/internal/installationinfo/buildinfo.go
+++ b/internal/installationinfo/buildinfo.go
@@ -1,0 +1,9 @@
+package installationinfo
+
+type buildInfo struct {
+	Commit  string
+	Version string
+	Date    string
+}
+
+var Build = &buildInfo{}

--- a/internal/installationinfo/runtimeinfo.go
+++ b/internal/installationinfo/runtimeinfo.go
@@ -1,0 +1,55 @@
+package installationinfo
+
+import (
+	"bufio"
+	"errors"
+	"os"
+	"runtime"
+	"strings"
+)
+
+type runtimeInfo struct {
+	OS                   string
+	OSReleasePrettyName  string
+	Arch                 string
+	InContainer          bool
+	LastBrowserUserAgent string
+}
+
+func isInContainer() bool {
+	if _, err := os.Stat("/.dockerenv"); errors.Is(err, os.ErrNotExist) {
+		return false
+	}
+
+	return true
+}
+
+func getOsReleasePrettyName() string {
+	handle, err := os.Open("/etc/os-release")
+
+	if err != nil {
+		return ""
+	}
+
+	scanner := bufio.NewScanner(handle)
+	scanner.Split(bufio.ScanLines)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if strings.Contains(line, "PRETTY_NAME") {
+			return line
+		}
+	}
+
+	handle.Close()
+
+	return "notfound"
+}
+
+var Runtime = &runtimeInfo{
+	OS:                  runtime.GOOS,
+	Arch:                runtime.GOARCH,
+	InContainer:         isInContainer(),
+	OSReleasePrettyName: getOsReleasePrettyName(),
+}

--- a/internal/installationinfo/sosreport.go
+++ b/internal/installationinfo/sosreport.go
@@ -1,0 +1,39 @@
+package installationinfo
+
+import (
+	"fmt"
+	config "github.com/OliveTin/OliveTin/internal/config"
+	"gopkg.in/yaml.v3"
+)
+
+var Config *config.Config
+
+type sosReportConfig struct {
+	CountOfActions int
+	LogLevel       string
+}
+
+func configToSosreport(cfg *config.Config) *sosReportConfig {
+	return &sosReportConfig{
+		CountOfActions: len(cfg.Actions),
+		LogLevel:       cfg.LogLevel,
+	}
+}
+
+func GetSosReport() string {
+	ret := ""
+
+	ret += "### SOSREPORT START (copy all text to SOSREPORT END)\n"
+
+	out, _ := yaml.Marshal(Build)
+	ret += fmt.Sprintf("# Build: \n%+v\n", string(out))
+
+	out, _ = yaml.Marshal(Runtime)
+	ret += fmt.Sprintf("# Runtime:\n%+v\n", string(out))
+
+	out, _ = yaml.Marshal(configToSosreport(Config))
+	ret += fmt.Sprintf("# Config:\n%+v\n", string(out))
+	ret += "### SOSREPORT END  (copy all text from SOSREPORT START)\n"
+
+	return ret
+}

--- a/internal/updatecheck/updateCheck.go
+++ b/internal/updatecheck/updateCheck.go
@@ -3,15 +3,14 @@ package updatecheck
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	config "github.com/OliveTin/OliveTin/internal/config"
+	installationinfo "github.com/OliveTin/OliveTin/internal/installationinfo"
 	"github.com/google/uuid"
 	"github.com/robfig/cron/v3"
 	log "github.com/sirupsen/logrus"
 	"io/ioutil"
 	"net/http"
 	"os"
-	"runtime"
 )
 
 type updateRequest struct {
@@ -63,14 +62,6 @@ func installationID(filename string) string {
 	return content
 }
 
-func isInContainer() bool {
-	if _, err := os.Stat("/.dockerenv"); errors.Is(err, os.ErrNotExist) {
-		return false
-	}
-
-	return true
-}
-
 // StartUpdateChecker will start a job that runs periodically, checking
 // for updates.
 func StartUpdateChecker(currentVersion string, currentCommit string, cfg *config.Config, configDir string) {
@@ -84,10 +75,10 @@ func StartUpdateChecker(currentVersion string, currentCommit string, cfg *config
 	payload := updateRequest{
 		CurrentVersion: currentVersion,
 		CurrentCommit:  currentCommit,
-		OS:             runtime.GOOS,
-		Arch:           runtime.GOARCH,
+		OS:             installationinfo.Runtime.OS,
+		Arch:           installationinfo.Runtime.Arch,
 		InstallationID: installationID(configDir + "/installation-id.txt"),
-		InContainer:    isInContainer(),
+		InContainer:    installationinfo.Runtime.InContainer,
 	}
 
 	s := cron.New(cron.WithSeconds())


### PR DESCRIPTION
This PR creates a sosreport (https://github.com/sosreport/sos) style debug output in the logs that is extremely helpful for helping out people with support issues. A sosreport can be generated by going to `/api/sosreport`, and the content is logged by OliveTin's standard output.

Here is an example; 

```
### SOSREPORT START (copy all text to SOSREPORT END)
# Build:
commit: nocommit
version: dev
date: nodate

# Runtime:
os: linux
osreleaseprettyname: PRETTY_NAME="Fedora Linux 37 (Workstation Edition)"
arch: amd64
incontainer: false
lastbrowseruseragent: ""

# Config:
countofactions: 7
loglevel: INFO

### SOSREPORT END  (copy all text from SOSREPORT START)
```
