### PR TITLE
cicd: Remote node_modules from integration tests upload

### DIFF
--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -74,4 +74,6 @@ jobs:
         uses: actions/upload-artifact@v3.1.0
         with:
           name: integration-tests
-          path: integration-tests
+          path: |
+            integration-tests
+            !integration-tests/node_modules


### PR DESCRIPTION
The integration-tests GitHub artifact was uploading 6000+ node_modules files, which takes 15+ minutes. Anyone wanting to use these integration-tests in this way can `npm install` them much faster, without any risk. 