### PR TITLE
feature: Reduce debug log spam in ACL/getDashboardComponents

### DIFF
--- a/internal/acl/acl.go
+++ b/internal/acl/acl.go
@@ -25,7 +25,7 @@ func IsAllowedExec(cfg *config.Config, user *AuthenticatedUser, action *config.A
 				"User":   user.Username,
 				"Action": action.Title,
 				"ACL":    acl.Name,
-			}).Debug("isAllowedExec - Matched ACL")
+			}).Trace("isAllowedExec - Matched ACL")
 
 			return true
 		}
@@ -34,7 +34,7 @@ func IsAllowedExec(cfg *config.Config, user *AuthenticatedUser, action *config.A
 	log.WithFields(log.Fields{
 		"User":   user.Username,
 		"Action": action.Title,
-	}).Debug("isAllowedExec - No ACLs matched")
+	}).Trace("isAllowedExec - No ACLs matched")
 
 	return cfg.DefaultPermissions.Exec
 }
@@ -47,7 +47,7 @@ func IsAllowedView(cfg *config.Config, user *AuthenticatedUser, action *config.A
 				"User":   user.Username,
 				"Action": action.Title,
 				"ACL":    acl.Name,
-			}).Debug("isAllowedView - Matched ACL")
+			}).Trace("isAllowedView - Matched ACL")
 
 			return true
 		}
@@ -56,7 +56,7 @@ func IsAllowedView(cfg *config.Config, user *AuthenticatedUser, action *config.A
 	log.WithFields(log.Fields{
 		"User":   user.Username,
 		"Action": action.Title,
-	}).Debug("isAllowedView - No ACLs matched")
+	}).Trace("isAllowedView - No ACLs matched")
 
 	return cfg.DefaultPermissions.View
 }

--- a/internal/grpcapi/grpcApi.go
+++ b/internal/grpcapi/grpcApi.go
@@ -115,7 +115,7 @@ func (api *oliveTinAPI) GetDashboardComponents(ctx ctx.Context, req *pb.GetDashb
 		log.Warn("Zero actions found - check that you have some actions defined, with a view permission")
 	}
 
-	log.Debugf("GetDashboardComponents: %v", res)
+	log.Tracef("GetDashboardComponents: %v", res)
 
 	return res, nil
 }


### PR DESCRIPTION
This reduces log spam seen when setting logLevel: DEBUG, by changing several log messages to TRACE instead.

When debugging another issue with logLevel set to DEBUG, on each http request OliveTin was generating something like 30 lines of output - which is ridiculous. 

For debugging deep ACL issues, TRACE is more appropriate anyway.