### PR TITLE
feature: Add actionTitle to blocked log messages

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -167,7 +167,9 @@ func stepConcurrencyCheck(req *ExecutionRequest) bool {
 	if concurrentCount >= (req.action.MaxConcurrent + 1) {
 		msg := fmt.Sprintf("Blocked from executing. This would mean this action is running %d times concurrently, but this action has maxExecutions set to %d.", concurrentCount, req.action.MaxConcurrent)
 
-		log.Warnf(msg)
+		log.WithFields(log.Fields{
+			"actionTitle": req.ActionName,
+		}).Warnf(msg)
 
 		req.logEntry.Stdout = msg
 		req.logEntry.Blocked = true


### PR DESCRIPTION
This is a minor PR that adjusts a log message, for example; 

```
INFO Action requested                              actionTitle="Run backup script"
WARN Blocked from executing. This would mean this action is running 2 times concurrently, but this action has maxExecutions set to 1.  actionTitle="Run backup script"
```