### PR TITLE
feature: #202 Cron seconds support optional. Example in default config.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -21,6 +21,9 @@ actions:
   shellAfterCompleted: "apprise -t 'Notification: Backup script completed' -b 'The backup script completed with code {{ exitCode}}. The log is: \n {{ stdout }} '"
   maxConcurrent: 1
   icon: backup
+  execOnCron: # https://docs.olivetin.app/exec-cron.html
+    - "@monthly"     # Once per month
+    - "0 12 25 12 *" # And on Christmas day!
 
   # This will send 1 ping (-c 1)
   # Docs: https://docs.olivetin.app/action-ping.html

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -88,6 +88,7 @@ type Config struct {
 	DefaultPermissions              PermissionsList
 	AccessControlLists              []AccessControlList
 	WebUIDir                        string
+	CronSupportForSeconds           bool
 }
 
 // DefaultConfig gets a new Config structure with sensible default values.
@@ -110,6 +111,7 @@ func DefaultConfig() *Config {
 	config.AuthJwtClaimUsername = "name"
 	config.AuthJwtClaimUserGroup = "group"
 	config.WebUIDir = "./webui"
+	config.CronSupportForSeconds = false
 
 	return &config
 }

--- a/internal/oncron/cron.go
+++ b/internal/oncron/cron.go
@@ -9,7 +9,13 @@ import (
 )
 
 func Schedule(cfg *config.Config, ex *executor.Executor) {
-	scheduler := cron.New(cron.WithSeconds())
+	var scheduler *cron.Cron
+
+	if cfg.CronSupportForSeconds {
+		scheduler = cron.New(cron.WithSeconds())
+	} else {
+		scheduler = cron.New()
+	}
 
 	for _, action := range cfg.Actions {
 		for _, cronline := range action.ExecOnCron {


### PR DESCRIPTION
This adds seconds support as optional to cron (disabled by default). https://docs.olivetin.app/exec-cron.html 