### PR TITLE
bugfix: #230 Set public-url in parcel to .

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ webui-codestyle:
 webui-dist:
 	rm -rf webui webui.dev/dist
 	cd webui.dev && npm install
-	cd webui.dev && parcel build && mv dist ../webui
+	cd webui.dev && parcel build --public-url "." && mv dist ../webui
 
 clean:
 	rm -rf dist OliveTin OliveTin.armhf OliveTin.exe reports gen


### PR DESCRIPTION
The last release introduced parcel to bundle assets, which uses absolute URIs by default. This PR changes the "public-url" to ".", making the asset URIs for Javascript, Stylesheets, etc relative to the document.

This is necessary for people who proxy OliveTin with a different document path (#192). 