### PR TITLE
bugfix: The web interface now refreshes when the config file is changed!

### DIFF
--- a/OliveTin.proto
+++ b/OliveTin.proto
@@ -184,6 +184,8 @@ message GetReadyzResponse {
 	string status = 1;
 }
 
+message EventConfigChanged {}
+
 service OliveTinApiService {
 	rpc GetDashboardComponents(GetDashboardComponentsRequest) returns (GetDashboardComponentsResponse) {
 		option (google.api.http) = {

--- a/cmd/OliveTin/main.go
+++ b/cmd/OliveTin/main.go
@@ -137,6 +137,7 @@ func main() {
 
 	executor := executor.DefaultExecutor()
 	executor.AddListener(websocket.ExecutionListener)
+	config.AddListener(websocket.OnConfigChanged)
 
 	go onstartup.Execute(cfg, executor)
 	go oncron.Schedule(cfg, executor)

--- a/internal/config/config_reloader.go
+++ b/internal/config/config_reloader.go
@@ -21,7 +21,13 @@ var (
 		Name: "olivetin_config_reloaded_count",
 		Help: "The number of times the config has been reloaded",
 	})
+
+	listeners []func()
 )
+
+func AddListener(l func()) {
+	listeners = append(listeners, l)
+}
 
 func Reload(cfg *Config) {
 	if err := viper.UnmarshalExact(&cfg); err != nil {
@@ -34,4 +40,8 @@ func Reload(cfg *Config) {
 
 	cfg.SetDir(path.Dir(viper.ConfigFileUsed()))
 	cfg.Sanitize()
+
+	for _, l := range listeners {
+		l()
+	}
 }

--- a/internal/websocket/websocket.go
+++ b/internal/websocket/websocket.go
@@ -6,6 +6,7 @@ import (
 	ws "github.com/gorilla/websocket"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/reflect/protoreflect"
 	"net/http"
 )
 
@@ -22,6 +23,12 @@ var clients []*WebsocketClient
 var marshalOptions = protojson.MarshalOptions{
 	UseProtoNames:   false, // eg: canExec for js instead of can_exec from protobuf
 	EmitUnpopulated: true,
+}
+
+func OnConfigChanged() {
+	evt := &pb.EventConfigChanged{}
+
+	broadcast(evt)
 }
 
 var ExecutionListener WebsocketExecutionListener
@@ -72,11 +79,18 @@ func (WebsocketExecutionListener) OnExecutionFinished(logEntry *executor.Interna
 		ExecutionFinished:   logEntry.ExecutionFinished,
 	}
 
-	broadcast("ExecutionFinished", le)
+	broadcast(le)
 }
 
-func broadcast(messageType string, pbmsg *pb.LogEntry) {
+func broadcast(pbmsg protoreflect.ProtoMessage) {
 	payload, err := marshalOptions.Marshal(pbmsg)
+
+	if err != nil {
+		log.Errorf("websocket marshal error: %v", err)
+		return
+	}
+
+	messageType := pbmsg.ProtoReflect().Descriptor().FullName()
 
 	// <EVIL>
 	// So, the websocket wants to encode messages using the same protomarshaller
@@ -97,13 +111,8 @@ func broadcast(messageType string, pbmsg *pb.LogEntry) {
 	hackyMessage = append(hackyMessage, []byte("}")...)
 	// </EVIL>
 
-	if err != nil {
-		log.Errorf("websocket marshal error: %v", err)
-		return
-	}
-
 	for _, client := range clients {
-		client.conn.WriteMessage(1, hackyMessage)
+		client.conn.WriteMessage(ws.TextMessage, hackyMessage)
 	}
 }
 

--- a/webui.dev/js/websocket.js
+++ b/webui.dev/js/websocket.js
@@ -40,6 +40,7 @@ function websocketOnMessage (msg) {
   e.payload = j.payload
 
   switch (j.type) {
+    case 'EventConfigChanged':
     case 'ExecutionFinished':
       window.dispatchEvent(e)
       break

--- a/webui.dev/main.js
+++ b/webui.dev/main.js
@@ -134,6 +134,8 @@ function main () {
   initMarshaller()
   setupLogSearchBox()
 
+  window.addEventListener('EventConfigChanged', fetchGetDashboardComponents) // For websocket
+
   window.fetch('webUiSettings.json').then(res => {
     return res.json()
   }).then(res => {


### PR DESCRIPTION
OliveTin stopped "refreshing" the web UI when it moved to web sockets. This change re-introduces a "config changed event", forcing the UI to refresh. 