### PR TITLE
doc: fix default licenses in package.json

### DIFF
--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -9,7 +9,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
-  "license": "ISC",
+  "license": "AGPL-3.0-only",
   "devDependencies": {
     "chai": "^5.1.0",
     "eslint": "^8.51.0",

--- a/webui.dev/package.json
+++ b/webui.dev/package.json
@@ -26,5 +26,5 @@
 		"OliveTinLogo-120px.png",
 		"OliveTinLogo-180px.png"
   ],
-  "license": "ISC"
+  "license": "AGPL-3.0-only"
 }


### PR DESCRIPTION
OliveTin has always been AGPL V3 only. This os declared by the top level LICENSE file. 

Npm just defaults to ISC. 