### PR TITLE
feature: The executor now controls the public action map - meaning actions work without the API, and pages load faster (and much more!)

### DIFF
--- a/OliveTin.proto
+++ b/OliveTin.proto
@@ -12,6 +12,7 @@ message Action {
 	bool can_exec = 4;
 	repeated ActionArgument arguments = 5;
 	string popup_on_start = 6;
+	int32 order = 7;
 }
 
 message ActionArgument {

--- a/cmd/OliveTin/main.go
+++ b/cmd/OliveTin/main.go
@@ -136,6 +136,7 @@ func main() {
 	log.Debugf("Config: %+v", cfg)
 
 	executor := executor.DefaultExecutor(cfg)
+	executor.RebuildActionMap()
 	executor.AddListener(websocket.ExecutionListener)
 	config.AddListener(executor.RebuildActionMap)
 

--- a/cmd/OliveTin/main.go
+++ b/cmd/OliveTin/main.go
@@ -135,9 +135,9 @@ func main() {
 
 	log.Debugf("Config: %+v", cfg)
 
-	executor := executor.DefaultExecutor()
+	executor := executor.DefaultExecutor(cfg)
 	executor.AddListener(websocket.ExecutionListener)
-	config.AddListener(websocket.OnConfigChanged)
+	config.AddListener(executor.RebuildActionMap)
 
 	go onstartup.Execute(cfg, executor)
 	go oncron.Schedule(cfg, executor)
@@ -145,6 +145,7 @@ func main() {
 	go oncalendarfile.Schedule(cfg, executor)
 
 	entityfiles.AddListener(websocket.OnEntityChanged)
+	entityfiles.AddListener(executor.RebuildActionMap)
 	go entityfiles.SetupEntityFileWatchers(cfg)
 
 	go updatecheck.StartUpdateChecker(version, commit, cfg, cfg.GetDir())

--- a/internal/executor/executor_actions.go
+++ b/internal/executor/executor_actions.go
@@ -1,0 +1,89 @@
+package executor
+
+import (
+	"crypto/sha256"
+	"fmt"
+	config "github.com/OliveTin/OliveTin/internal/config"
+	sv "github.com/OliveTin/OliveTin/internal/stringvariables"
+	log "github.com/sirupsen/logrus"
+	"strconv"
+)
+
+func (e *Executor) FindActionBindingByID(id string) *config.Action {
+	e.MapActionIdToBindingLock.RLock()
+	pair, found := e.MapActionIdToBinding[id]
+	e.MapActionIdToBindingLock.RUnlock()
+
+	if found {
+		log.Infof("findActionBinding %v, %v", id, pair.Action.ID)
+		return pair.Action
+	}
+
+	return nil
+}
+
+func (e *Executor) RebuildActionMap() {
+	e.MapActionIdToBindingLock.Lock()
+
+	clear(e.MapActionIdToBinding)
+
+	for configOrder, action := range e.Cfg.Actions {
+		if action.Entity != "" {
+			registerActionsFromEntities(e, configOrder, action.Entity, action)
+		} else {
+			registerAction(e, configOrder, action)
+		}
+	}
+
+	e.MapActionIdToBindingLock.Unlock()
+
+	for _, l := range e.listeners {
+		l.OnActionMapRebuilt()
+	}
+}
+
+func registerAction(e *Executor, configOrder int, action *config.Action) {
+	actionId := hashActionToID(action, "")
+
+	e.MapActionIdToBinding[actionId] = &ActionBinding{
+		Action:       action,
+		EntityPrefix: "noent",
+		ConfigOrder:  configOrder,
+	}
+}
+
+func registerActionsFromEntities(e *Executor, configOrder int, entityTitle string, tpl *config.Action) {
+	entityCount, _ := strconv.Atoi(sv.Get("entities." + entityTitle + ".count"))
+
+	for i := 0; i < entityCount; i++ {
+		registerActionFromEntity(e, configOrder, tpl, entityTitle, i)
+	}
+}
+
+func registerActionFromEntity(e *Executor, configOrder int, tpl *config.Action, entityTitle string, entityIndex int) {
+	prefix := sv.GetEntityPrefix(entityTitle, entityIndex)
+
+	virtualActionId := hashActionToID(tpl, prefix)
+
+	e.MapActionIdToBinding[virtualActionId] = &ActionBinding{
+		Action:       tpl,
+		EntityPrefix: prefix,
+		ConfigOrder:  configOrder,
+	}
+}
+
+func hashActionToID(action *config.Action, entityPrefix string) string {
+	if action.ID != "" && entityPrefix == "" {
+		return action.ID
+	}
+
+	h := sha256.New()
+
+	if entityPrefix == "" {
+		h.Write([]byte(action.Title))
+	} else {
+		h.Write([]byte(action.ID + "." + entityPrefix))
+	}
+
+	return fmt.Sprintf("%x", h.Sum(nil))
+}

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -9,9 +9,9 @@ import (
 )
 
 func testingExecutor() (*Executor, *config.Config) {
-	e := DefaultExecutor()
-
 	cfg := config.DefaultConfig()
+
+	e := DefaultExecutor(cfg)
 
 	a1 := &config.Action{
 		Title: "Do some tickles",

--- a/internal/grpcapi/grpcApiActions.go
+++ b/internal/grpcapi/grpcApiActions.go
@@ -1,90 +1,47 @@
 package grpcapi
 
 import (
-	"crypto/sha256"
-	"fmt"
 	pb "github.com/OliveTin/OliveTin/gen/grpc"
 	acl "github.com/OliveTin/OliveTin/internal/acl"
 	config "github.com/OliveTin/OliveTin/internal/config"
+	executor "github.com/OliveTin/OliveTin/internal/executor"
 	sv "github.com/OliveTin/OliveTin/internal/stringvariables"
-	log "github.com/sirupsen/logrus"
-	"strconv"
+	"sort"
 )
 
-type ActionWithEntity struct {
-	Action       *config.Action
-	EntityPrefix string
-}
-
-var publicActionIdToActionMap map[string]ActionWithEntity
-
-func init() {
-	publicActionIdToActionMap = make(map[string]ActionWithEntity)
-}
-
-func actionsCfgToPb(cfgActions []*config.Action, user *acl.AuthenticatedUser) *pb.GetDashboardComponentsResponse {
+func buildDashboardResponse(ex *executor.Executor, cfg *config.Config, user *acl.AuthenticatedUser) *pb.GetDashboardComponentsResponse {
 	res := &pb.GetDashboardComponentsResponse{}
 
-	for _, action := range cfgActions {
-		if !acl.IsAllowedView(cfg, user, action) {
+	ex.MapActionIdToBindingLock.RLock()
+
+	for actionId, actionBinding := range ex.MapActionIdToBinding {
+		if !acl.IsAllowedView(cfg, user, actionBinding.Action) {
 			continue
 		}
 
-		if action.Entity != "" {
-			res.Actions = append(res.Actions, buildActionEntities(action.Entity, action)...)
-		} else {
-			btn := actionCfgToPb(action, user)
-			res.Actions = append(res.Actions, btn)
-		}
+		res.Actions = append(res.Actions, buildAction(actionId, actionBinding, user))
 	}
+
+	ex.MapActionIdToBindingLock.RUnlock()
+
+	sort.Slice(res.Actions, func(i, j int) bool {
+		return res.Actions[i].Order < res.Actions[j].Order
+
+	})
 
 	return res
 }
 
-func buildActionEntities(entityTitle string, tpl *config.Action) []*pb.Action {
-	ret := make([]*pb.Action, 0)
-
-	entityCount, _ := strconv.Atoi(sv.Get("entities." + entityTitle + ".count"))
-
-	for i := 0; i < entityCount; i++ {
-		ret = append(ret, buildEntityAction(tpl, entityTitle, i))
-	}
-
-	return ret
-}
-
-func buildEntityAction(tpl *config.Action, entityTitle string, entityIndex int) *pb.Action {
-	prefix := sv.GetEntityPrefix(entityTitle, entityIndex)
-
-	virtualActionId := createPublicID(tpl, prefix)
-
-	publicActionIdToActionMap[virtualActionId] = ActionWithEntity{
-		Action:       tpl,
-		EntityPrefix: prefix,
-	}
-
-	return &pb.Action{
-		Id:           virtualActionId,
-		Title:        sv.ReplaceEntityVars(prefix, tpl.Title),
-		Icon:         tpl.Icon,
-		PopupOnStart: tpl.PopupOnStart,
-	}
-}
-
-func actionCfgToPb(action *config.Action, user *acl.AuthenticatedUser) *pb.Action {
-	virtualActionId := createPublicID(action, "")
-
-	publicActionIdToActionMap[virtualActionId] = ActionWithEntity{
-		Action:       action,
-		EntityPrefix: "noent",
-	}
+func buildAction(actionId string, actionBinding *executor.ActionBinding, user *acl.AuthenticatedUser) *pb.Action {
+	action := actionBinding.Action
 
 	btn := pb.Action{
-		Id:           virtualActionId,
-		Title:        action.Title,
+		Id:           actionId,
+		Title:        sv.ReplaceEntityVars(actionBinding.EntityPrefix, action.Title),
 		Icon:         action.Icon,
 		CanExec:      acl.IsAllowedExec(cfg, user, action),
 		PopupOnStart: action.PopupOnStart,
+		Order:        int32(actionBinding.ConfigOrder),
 	}
 
 	for _, cfgArg := range action.Arguments {
@@ -142,26 +99,4 @@ func buildChoicesSimple(choices []config.ActionArgumentChoice) []*pb.ActionArgum
 	}
 
 	return ret
-}
-
-func createPublicID(action *config.Action, entityPrefix string) string {
-	if action.Entity == "" {
-		return action.ID
-	} else {
-		h := sha256.New()
-		h.Write([]byte(action.ID + "." + entityPrefix))
-
-		return fmt.Sprintf("%x", h.Sum(nil))
-	}
-}
-
-func findActionByPublicID(id string) *config.Action {
-	pair, found := publicActionIdToActionMap[id]
-
-	if found {
-		log.Infof("findPublic %v, %v", id, pair.Action.ID)
-		return pair.Action
-	}
-
-	return nil
 }

--- a/internal/grpcapi/grpcApiActions.go
+++ b/internal/grpcapi/grpcApiActions.go
@@ -25,8 +25,11 @@ func buildDashboardResponse(ex *executor.Executor, cfg *config.Config, user *acl
 	ex.MapActionIdToBindingLock.RUnlock()
 
 	sort.Slice(res.Actions, func(i, j int) bool {
-		return res.Actions[i].Order < res.Actions[j].Order
-
+		if res.Actions[i].Order == res.Actions[j].Order {
+			return res.Actions[i].Title < res.Actions[j].Title
+		} else {
+			return res.Actions[i].Order < res.Actions[j].Order
+		}
 	})
 
 	return res

--- a/internal/grpcapi/grpcApi_test.go
+++ b/internal/grpcapi/grpcApi_test.go
@@ -21,8 +21,8 @@ const bufSize = 1024 * 1024
 
 var lis *bufconn.Listener
 
-func init() {
-	ex := executor.DefaultExecutor()
+func initServer(cfg *config.Config) *executor.Executor {
+	ex := executor.DefaultExecutor(cfg)
 
 	lis = bufconn.Listen(bufSize)
 	s := grpc.NewServer()
@@ -33,6 +33,8 @@ func init() {
 			log.Fatalf("Server exited with error: %v", err)
 		}
 	}()
+
+	return ex
 }
 
 func bufDialer(context.Context, string) (net.Conn, error) {
@@ -57,11 +59,16 @@ func getNewTestServerAndClient(t *testing.T, injectedConfig *config.Config) (*gr
 
 func TestGetActionsAndStart(t *testing.T) {
 	cfg = config.DefaultConfig()
+
+	ex := initServer(cfg)
+
 	btn1 := &config.Action{}
 	btn1.Title = "blat"
 	btn1.ID = "blat"
 	btn1.Shell = "echo 'test'"
 	cfg.Actions = append(cfg.Actions, btn1)
+
+	ex.RebuildActionMap()
 
 	conn, client := getNewTestServerAndClient(t, cfg)
 

--- a/internal/websocket/websocket.go
+++ b/internal/websocket/websocket.go
@@ -30,12 +30,6 @@ var marshalOptions = protojson.MarshalOptions{
 	EmitUnpopulated: true,
 }
 
-func OnConfigChanged() {
-	evt := &pb.EventConfigChanged{}
-
-	broadcast(evt)
-}
-
 var ExecutionListener WebsocketExecutionListener
 
 type WebsocketExecutionListener struct{}
@@ -51,6 +45,10 @@ func (WebsocketExecutionListener) OnExecutionStarted(title string) {
 
 func OnEntityChanged() {
 	broadcast(&pb.EventEntityChanged{})
+}
+
+func (WebsocketExecutionListener) OnActionMapRebuilt() {
+	broadcast(&pb.EventConfigChanged{})
 }
 
 /*
@@ -156,7 +154,11 @@ func HandleWebsocket(w http.ResponseWriter, r *http.Request) bool {
 		conn: c,
 	}
 
+	sendmutex.Lock()
+
 	clients = append(clients, wsclient)
+
+	sendmutex.Unlock()
 
 	go wsclient.messageLoop()
 


### PR DESCRIPTION
This is a pretty major OliveTin change. 

OliveTin actions in the configuration file do not necessarily map 1:1 to actions that can be started. The most notable example of this is entities, which "generate" buttons on the web UI from a single config entry. This means that OliveTin has to generate an ID for each individual button that can be started (as going by action titles with variables in them won't work). OliveTin has previously maintained this map in the grpc API, eg: 

- "1234" -> Start {{ container.Name }} | Plex
- "4567" -> Start {{ container.Name }} | Minecraft
- "8910" -> Start {{ container.Name }} | Haproxy

The problem is that this map is only updated / generated on requests to the API, specifically `GetDashboardComponents`. This created the following subtle problems;

- The action ID for entities is actually using a sha256 of the Action Title and the Entity Prefix, which is fine for a low number of entities, but if we're running a couple of entities, like 8 containers on a RPI, a sha256 hash isn't computationally trivial, causing page loads to take a second or two.
- If an API call is made to start an action by ID, like `restart_httpd`, and nobody has visited the OliveTin webpage yet, the action won't be found; #305 
- The dashboard buttons might easily fall out of sync with what actions can be used ( #155 ). 

This change moves the action map into the Executor, which in itself sounds like an incredibly trivial change, but in practice required a LOT of chunky reachitecting of the way OliveTin does things! 