### PR TITLE
feature: Customizable default directory, back and action icons

### DIFF
--- a/OliveTin.proto
+++ b/OliveTin.proto
@@ -54,6 +54,7 @@ message DashboardComponent {
 	string title = 1;
 	string type = 2;
 	repeated DashboardComponent contents = 3;
+	string icon = 4;
 }
 
 message StartActionRequest {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -121,6 +121,9 @@ type Config struct {
 	InsecureAllowDumpJwtClaims      bool
 	Prometheus                      PrometheusConfig
 	SaveLogs                        SaveLogsConfig
+	DefaultIconForActions           string
+	DefaultIconForDirectories       string
+	DefaultIconForBack              string
 
 	usedConfigDir string
 }
@@ -141,6 +144,7 @@ type DashboardComponent struct {
 	Title    string
 	Type     string
 	Entity   string
+	Icon     string
 	Contents []DashboardComponent
 }
 
@@ -175,6 +179,9 @@ func DefaultConfig() *Config {
 	config.InsecureAllowDumpJwtClaims = false
 	config.Prometheus.Enabled = false
 	config.Prometheus.DefaultGoMetrics = false
+	config.DefaultIconForActions = "&#x1F600;"
+	config.DefaultIconForDirectories = "&#128193"
+	config.DefaultIconForBack = "&laquo;"
 
 	return &config
 }

--- a/internal/config/emoji.go
+++ b/internal/config/emoji.go
@@ -1,7 +1,6 @@
 package config
 
 var emojis = map[string]string{
-	"":            "&#x1F600;", // default icon
 	"poop":        "&#x1f4a9;",
 	"smile":       "&#x1F600;",
 	"ping":        "&#x1f4e1;",
@@ -17,7 +16,11 @@ var emojis = map[string]string{
 	"robot":       "&#129302;",
 }
 
-func lookupHTMLIcon(keyToLookup string) string {
+func lookupHTMLIcon(keyToLookup string, defaultIcon string) string {
+	if keyToLookup == "" {
+		return defaultIcon
+	}
+
 	if emoji, found := emojis[keyToLookup]; found {
 		return emoji
 	}

--- a/internal/config/emoji_test.go
+++ b/internal/config/emoji_test.go
@@ -6,7 +6,9 @@ import (
 )
 
 func TestGetEmojiByShortName(t *testing.T) {
-	assert.Equal(t, "&#x1F600;", lookupHTMLIcon("smile"), "Find an eomji by short name")
+	assert.Equal(t, "&#x1F600;", lookupHTMLIcon("smile", "empty"), "Find an eomji by short name")
 
-	assert.Equal(t, "notfound", lookupHTMLIcon("notfound"), "Find an eomji by undefined short name")
+	assert.Equal(t, "empty", lookupHTMLIcon("", "empty"), "Find an eomji when the value is empty")
+
+	assert.Equal(t, "notfound", lookupHTMLIcon("notfound", "empty"), "Find an eomji by undefined short name")
 }

--- a/internal/config/sanitize.go
+++ b/internal/config/sanitize.go
@@ -31,7 +31,7 @@ func (action *Action) sanitize(cfg *Config) {
 	}
 
 	action.ID = getActionID(action)
-	action.Icon = lookupHTMLIcon(action.Icon)
+	action.Icon = lookupHTMLIcon(action.Icon, cfg.DefaultIconForActions)
 	action.PopupOnStart = sanitizePopupOnStart(action.PopupOnStart, cfg)
 
 	if action.MaxConcurrent < 1 {

--- a/internal/grpcapi/grpcApi.go
+++ b/internal/grpcapi/grpcApi.go
@@ -242,7 +242,7 @@ func (api *oliveTinAPI) GetDashboardComponents(ctx ctx.Context, req *pb.GetDashb
 
 	log.Tracef("GetDashboardComponents: %v", res)
 
-	dashboardCfgToPb(res, cfg.Dashboards)
+	dashboardCfgToPb(res, cfg.Dashboards, cfg)
 
 	res.AuthenticatedUser = user.Username
 

--- a/internal/grpcapi/grpcApiDashboard.go
+++ b/internal/grpcapi/grpcApiDashboard.go
@@ -6,17 +6,17 @@ import (
 	"golang.org/x/exp/slices"
 )
 
-func dashboardCfgToPb(res *pb.GetDashboardComponentsResponse, dashboards []*config.DashboardComponent) {
+func dashboardCfgToPb(res *pb.GetDashboardComponentsResponse, dashboards []*config.DashboardComponent, cfg *config.Config) {
 	for _, dashboard := range dashboards {
 		res.Dashboards = append(res.Dashboards, &pb.DashboardComponent{
 			Type:     "dashboard",
 			Title:    dashboard.Title,
-			Contents: getDashboardComponentContents(dashboard),
+			Contents: getDashboardComponentContents(dashboard, cfg),
 		})
 	}
 }
 
-func getDashboardComponentContents(dashboard *config.DashboardComponent) []*pb.DashboardComponent {
+func getDashboardComponentContents(dashboard *config.DashboardComponent, cfg *config.Config) []*pb.DashboardComponent {
 	ret := make([]*pb.DashboardComponent, 0)
 
 	for _, subitem := range dashboard.Contents {
@@ -28,13 +28,22 @@ func getDashboardComponentContents(dashboard *config.DashboardComponent) []*pb.D
 		newitem := &pb.DashboardComponent{
 			Title:    subitem.Title,
 			Type:     getDashboardComponentType(&subitem),
-			Contents: getDashboardComponentContents(&subitem),
+			Contents: getDashboardComponentContents(&subitem, cfg),
+			Icon:     getDashboardComponentIcon(&subitem, cfg),
 		}
 
 		ret = append(ret, newitem)
 	}
 
 	return ret
+}
+
+func getDashboardComponentIcon(item *config.DashboardComponent, cfg *config.Config) string {
+	if item.Icon == "" {
+		return cfg.DefaultIconForDirectories
+	}
+
+	return item.Icon
 }
 
 func getDashboardComponentType(item *config.DashboardComponent) string {

--- a/internal/httpservers/webuiServer.go
+++ b/internal/httpservers/webuiServer.go
@@ -28,6 +28,7 @@ type webUISettings struct {
 	CurrentVersion         string
 	PageTitle              string
 	SectionNavigationStyle string
+	DefaultIconForBack     string
 }
 
 func findWebuiDir() string {
@@ -109,6 +110,7 @@ func generateWebUISettings(w http.ResponseWriter, r *http.Request) {
 		CurrentVersion:         updatecheck.CurrentVersion,
 		PageTitle:              cfg.PageTitle,
 		SectionNavigationStyle: cfg.SectionNavigationStyle,
+		DefaultIconForBack:     cfg.DefaultIconForBack,
 	})
 
 	_, err := w.Write([]byte(jsonRet))

--- a/webui.dev/js/marshaller.js
+++ b/webui.dev/js/marshaller.js
@@ -453,7 +453,7 @@ function marshalDisplay (item, fieldset) {
 
 function marshalDirectoryButton (item, fieldset) {
   const directoryButton = document.createElement('button')
-  directoryButton.innerHTML = '<span class = "icon">&#128193;</span> ' + item.title
+  directoryButton.innerHTML = '<span class = "icon">' + item.icon + '</span> ' + item.title
   directoryButton.onclick = () => {
     changeDirectory(item.title)
   }
@@ -466,7 +466,7 @@ function marshalDirectory (item, section) {
   fs.style.display = 'none'
 
   const directoryBackButton = document.createElement('button')
-  directoryBackButton.innerHTML = '&laquo;'
+  directoryBackButton.innerHTML = window.settings.DefaultIconForBack
   directoryBackButton.title = 'Go back one directory'
   directoryBackButton.onclick = () => {
     changeDirectory('..')

--- a/webui.dev/main.js
+++ b/webui.dev/main.js
@@ -115,6 +115,8 @@ function processWebuiSettingsJson (settings) {
     const titleElem = document.querySelector('#page-title')
     if (titleElem) titleElem.innerText = window.pageTitle
   }
+
+  window.settings = settings
 }
 
 function main () {


### PR DESCRIPTION
Feature requested on discord. Will document soon. 

3 new config options;

`DefaultIconForDirectories`, `DefaultIconForActions`, `DefaultActionForBack`

Dashboard components now have a `icon` property, which is used for folders;

```
dashboards:
  - title: My dashboard
    contents:
      - title: My Folder
        icon: &#1F600
        contents:
          ...
```