### PR TITLE
Make it possible to redirect to a login url unless authenticated

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -179,6 +179,7 @@ func DefaultConfigWithBasePort(basePort int) *Config {
 	config.DefaultPermissions.Logs = true
 	config.AuthJwtClaimUsername = "name"
 	config.AuthJwtClaimUserGroup = "group"
+	config.AuthAllowGuest = true
 	config.WebUIDir = "./webui"
 	config.CronSupportForSeconds = false
 	config.SectionNavigationStyle = "sidebar"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -130,6 +130,7 @@ type Config struct {
 	DefaultIconForActions           string
 	DefaultIconForDirectories       string
 	DefaultIconForBack              string
+	UrlOnUnauthenticated            string
 
 	usedConfigDir string
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -130,7 +130,8 @@ type Config struct {
 	DefaultIconForActions           string
 	DefaultIconForDirectories       string
 	DefaultIconForBack              string
-	UrlOnUnauthenticated            string
+	AuthLoginUrl                    string
+	AuthAllowGuest                  bool
 
 	usedConfigDir string
 }

--- a/internal/grpcapi/grpcApi.go
+++ b/internal/grpcapi/grpcApi.go
@@ -2,6 +2,7 @@ package grpcapi
 
 import (
 	ctx "context"
+
 	pb "github.com/OliveTin/OliveTin/gen/grpc"
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
@@ -254,6 +255,10 @@ func (api *oliveTinAPI) GetDashboardComponents(ctx ctx.Context, req *pb.GetDashb
 	dashboardCfgToPb(res, cfg.Dashboards, cfg)
 
 	res.AuthenticatedUser = user.Username
+
+	if res.AuthenticatedUser == "" && cfg.UrlOnUnauthenticated != "" {
+		return nil, errors.New("unauthenticated")
+	}
 
 	return res, nil
 }

--- a/internal/grpcapi/grpcApi.go
+++ b/internal/grpcapi/grpcApi.go
@@ -266,8 +266,8 @@ func (api *oliveTinAPI) GetDashboardComponents(ctx ctx.Context, req *pb.GetDashb
 
 	res.AuthenticatedUser = user.Username
 
-	if res.AuthenticatedUser == "" && cfg.UrlOnUnauthenticated != "" {
-		return nil, errors.New("unauthenticated")
+	if res.AuthenticatedUser == "guest" && !cfg.AuthAllowGuest {
+		return nil, status.Errorf(codes.PermissionDenied, "Unauthenticated")
 	}
 
 	return res, nil

--- a/internal/httpservers/restapi.go
+++ b/internal/httpservers/restapi.go
@@ -5,7 +5,9 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
 	"net/http"
 
@@ -83,10 +85,21 @@ func startRestAPIServer(globalConfig *config.Config) error {
 	return http.ListenAndServe(cfg.ListenAddressRestActions, cors.AllowCors(mux))
 }
 
+func errorHandler(ctx context.Context, mux *runtime.ServeMux, marshaler runtime.Marshaler, w http.ResponseWriter, r *http.Request, err error) {
+	log.Errorf("Error handling request: %v", err)
+	md, ok := runtime.ServerMetadataFromContext(ctx)
+	if ok && md.HeaderMD.Get("username") == nil {
+		err = status.Error(codes.Unauthenticated, "unauthenticated request")
+	}
+
+	runtime.DefaultHTTPErrorHandler(ctx, mux, marshaler, w, r, err)
+}
+
 func newMux() *runtime.ServeMux {
 	// The MarshalOptions set some important compatibility settings for the webui. See below.
 	mux := runtime.NewServeMux(
 		runtime.WithMetadata(parseRequestMetadata),
+		runtime.WithErrorHandler(errorHandler),
 		runtime.WithMarshalerOption(runtime.MIMEWildcard, &runtime.HTTPBodyMarshaler{
 			Marshaler: &runtime.JSONPb{
 				MarshalOptions: protojson.MarshalOptions{

--- a/internal/httpservers/webuiServer.go
+++ b/internal/httpservers/webuiServer.go
@@ -32,6 +32,7 @@ type webUISettings struct {
 	SshFoundKey            string
 	SshFoundConfig         string
 	EnableCustomJs         bool
+	UrlOnUnauthenticated   string
 }
 
 func findWebuiDir() string {
@@ -117,6 +118,7 @@ func generateWebUISettings(w http.ResponseWriter, r *http.Request) {
 		SshFoundKey:            installationinfo.Runtime.SshFoundKey,
 		SshFoundConfig:         installationinfo.Runtime.SshFoundConfig,
 		EnableCustomJs:         cfg.EnableCustomJs,
+		UrlOnUnauthenticated:   cfg.UrlOnUnauthenticated,
 	})
 
 	w.Header().Add("Content-Type", "application/json")

--- a/internal/httpservers/webuiServer.go
+++ b/internal/httpservers/webuiServer.go
@@ -32,7 +32,7 @@ type webUISettings struct {
 	SshFoundKey            string
 	SshFoundConfig         string
 	EnableCustomJs         bool
-	UrlOnUnauthenticated   string
+	AuthLoginUrl           string
 }
 
 func findWebuiDir() string {
@@ -118,7 +118,7 @@ func generateWebUISettings(w http.ResponseWriter, r *http.Request) {
 		SshFoundKey:            installationinfo.Runtime.SshFoundKey,
 		SshFoundConfig:         installationinfo.Runtime.SshFoundConfig,
 		EnableCustomJs:         cfg.EnableCustomJs,
-		UrlOnUnauthenticated:   cfg.UrlOnUnauthenticated,
+		AuthLoginUrl:           cfg.AuthLoginUrl,
 	})
 
 	w.Header().Add("Content-Type", "application/json")

--- a/webui.dev/main.js
+++ b/webui.dev/main.js
@@ -58,6 +58,9 @@ function fetchGetDashboardComponents () {
   window.fetch(window.restBaseUrl + 'GetDashboardComponents', {
     cors: 'cors'
   }).then(res => {
+    if (!res.ok && res.status === 401) {
+      window.location.href = window.settings.UrlOnUnauthenticated
+    }
     return res.json()
   }).then(res => {
     if (!window.restAvailable) {

--- a/webui.dev/main.js
+++ b/webui.dev/main.js
@@ -59,7 +59,7 @@ function fetchGetDashboardComponents () {
     cors: 'cors'
   }).then(res => {
     if (!res.ok && res.status === 401) {
-      window.location.href = window.settings.UrlOnUnauthenticated
+      window.location.href = window.settings.AuthLoginUrl
     }
     return res.json()
   }).then(res => {


### PR DESCRIPTION
# PR Introduction

This is an initial attempt of adding a feature to navigate to a configured url if configured and user is not authenticated.
basically

As a end user I want to end up on a login page if I am not authenticated
so that it is clear that I am not authenticated and can easily log in again.

I do not know the codebase well yet, so it is quite possible that I have done something stupid and/or missed something obvious.

Opening PR early for feedback.

Known issues: 
- `make daemon-unittests` panic for some reason
- `make daemon-compile`: go: unsupported GOOS/GOARCH pair darwin/arm
- docs

# Checklist
Please put a X in the boxes as evidence of reading through the checklist.

- [x] I have forked the project, and raised this PR on a feature branch.
- [x] `make githooks` has been run, and my git commit message was accepted by the git hook.
- [ ] `make daemon-compile` runs without any issues.
- [x] `make daemon-codestyle` runs without any issues.
- [ ] `make daemon-unittests` runs without any issues.
- [x] `make webui-codestyle` runs without any issues.
- [x] I understand and accept the [AGPL-3.0 license](LICENSE) and [code of conduct](CODE_OF_CONDUCT.md), and my contributions fall under these.
