### PR TITLE
depbump: Upgrade Go to 1.21

### DIFF
--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -33,8 +33,11 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.18.0'
+          go-version-file: 'go.mod'
           cache: true
+
+      - name: Print go version
+        run: go version
 
       - name: grpc
         run: make -w grpc

--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -31,8 +31,11 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.18.0'
+          go-version-file: 'go.mod'
           cache: true
+
+      - name: Print go version
+        run: go version
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2

--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -21,8 +21,11 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '^1.18.0'
+          go-version-file: 'go.mod'
           cache: true
+
+      - name: Print go version
+        run: go version
 
       - name: deps
         run: make -w grpc


### PR DESCRIPTION
Previous builds were set to use the version statically, 1.18. Updating the actions to use go.mod (1.21). 

This might also help with some weird windows issues seen recently. 