### PR TITLE
bugfix: Empty environment variable names causing exec failures on Windows, thanks @sirjmann92 !

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -380,7 +380,14 @@ func buildEnv(req *ExecutionRequest) []string {
 	ret := append(os.Environ(), "OLIVETIN=1")
 
 	for k, v := range req.Arguments {
-		ret = append(ret, fmt.Sprintf("%v=%v", strings.ToUpper(k), v))
+		varName := fmt.Sprintf("%v", strings.TrimSpace(strings.ToUpper(k)))
+
+		// Skip arguments that might not have a name (eg, confirmation), as this causes weird bugs on Windows.
+		if varName == "" {
+			continue
+		}
+
+		ret = append(ret, fmt.Sprintf("%v=%v", varName, v))
 	}
 
 	return ret


### PR DESCRIPTION
Just after OliveTin 2024.04.261, I added support for all arguments to be exposed as environment variables to running actions, with this code; 

```go
+       for k, v := range req.Arguments {
+               ret = append(ret, fmt.Sprintf("%v=%v", strings.ToUpper(k), v))
+       }
```

This is fine, but sometimes arguments don't contain a name (this isn't necessarily required, for example with `type: confirm`);

```yaml
actions:
  - title: foo
    shell: echo "foo"
    arguments:
      - type: confirm
```

So OliveTin was trying to set an environment variable called "" - the name of the "confirm" type argument. Linux silently ignored this, but Windows exits with this weird error message - "exec/fork" ... "The parameter is incorrect"

![image](https://github.com/user-attachments/assets/83ccc16d-59c3-48ce-a0af-b1ea3df98f2c)

The solution, therefore, is to not try and set environment variables with the name "". 

I could issue a warning, or and error, if an argument does not have a name, but there are times (like with confirmation), where you don't need the argument to have a name.

A huge thanks to @sirjmann92 for reporting this weird, hard to reproduce bug (I upgraded to Windows 11 to reproduce it!). This is what the power of the community on Discord can do! 