### PR TITLE
feature: #350 Environment variable PORT can be used to override the default 1337, and internal services will calculate their port based on that

### DIFF
--- a/cmd/OliveTin/main.go
+++ b/cmd/OliveTin/main.go
@@ -20,6 +20,7 @@ import (
 	config "github.com/OliveTin/OliveTin/internal/config"
 	"github.com/fsnotify/fsnotify"
 	"github.com/spf13/viper"
+	"strconv"
 	"os"
 )
 
@@ -76,6 +77,32 @@ func initCliFlags() string {
 	return configDir
 }
 
+func getBasePort() int {
+	var err error
+
+	defaultPort := 1337
+	basePort := defaultPort
+
+	envPort := os.Getenv("PORT")
+
+	if envPort != "" {
+		basePort, err = strconv.Atoi(os.Getenv("PORT"))
+
+		if err != nil {
+			log.Errorf("Error converting port to int. %s", err)
+			os.Exit(1)
+		}
+	}
+
+	if defaultPort != basePort {
+		log.WithFields(log.Fields{
+			"basePort": basePort,
+		}).Debug("Base port")
+	}
+
+	return basePort
+}
+
 func initViperConfig(configDir string) {
 	viper.AutomaticEnv()
 	viper.SetConfigName("config.yaml")
@@ -89,7 +116,7 @@ func initViperConfig(configDir string) {
 		os.Exit(1)
 	}
 
-	cfg = config.DefaultConfig()
+	cfg = config.DefaultConfigWithBasePort(getBasePort())
 
 	viper.WatchConfig()
 	viper.OnConfigChange(func(e fsnotify.Event) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,5 +1,9 @@
 package config
 
+import (
+	"fmt"
+)
+
 // Action represents the core functionality of OliveTin - commands that show up
 // as buttons in the UI.
 type Action struct {
@@ -148,19 +152,18 @@ type DashboardComponent struct {
 	Contents []DashboardComponent
 }
 
-// DefaultConfig gets a new Config structure with sensible default values.
 func DefaultConfig() *Config {
+	return DefaultConfigWithBasePort(1337)
+}
+
+// DefaultConfig gets a new Config structure with sensible default values.
+func DefaultConfigWithBasePort(basePort int) *Config {
 	config := Config{}
 	config.UseSingleHTTPFrontend = true
 	config.PageTitle = "OliveTin"
 	config.ShowFooter = true
 	config.ShowNavigation = true
 	config.ShowNewVersions = true
-	config.ListenAddressSingleHTTPFrontend = "0.0.0.0:1337"
-	config.ListenAddressRestActions = "localhost:1338"
-	config.ListenAddressGrpcActions = "localhost:1339"
-	config.ListenAddressWebUI = "localhost:1340"
-	config.ListenAddressPrometheus = "localhost:1341"
 	config.ExternalRestAddress = "."
 	config.LogLevel = "INFO"
 	config.CheckForUpdates = false
@@ -182,6 +185,12 @@ func DefaultConfig() *Config {
 	config.DefaultIconForActions = "&#x1F600;"
 	config.DefaultIconForDirectories = "&#128193"
 	config.DefaultIconForBack = "&laquo;"
+
+	config.ListenAddressSingleHTTPFrontend = fmt.Sprintf("0.0.0.0:%d", basePort)
+	config.ListenAddressRestActions = fmt.Sprintf("localhost:%d", basePort+1)
+	config.ListenAddressGrpcActions = fmt.Sprintf("localhost:%d", basePort+2)
+	config.ListenAddressWebUI = fmt.Sprintf("localhost:%d", basePort+3)
+	config.ListenAddressPrometheus = fmt.Sprintf("localhost:%d", basePort+4)
 
 	return &config
 }

--- a/internal/grpcapi/grpcApi.go
+++ b/internal/grpcapi/grpcApi.go
@@ -382,6 +382,10 @@ func (api *oliveTinAPI) GetReadyz(ctx ctx.Context, req *pb.GetReadyzRequest) (*p
 func Start(globalConfig *config.Config, ex *executor.Executor) {
 	cfg = globalConfig
 
+	log.WithFields(log.Fields{
+		"address": cfg.ListenAddressGrpcActions,
+	}).Info("Starting gRPC API")
+
 	lis, err := net.Listen("tcp", cfg.ListenAddressGrpcActions)
 
 	if err != nil {

--- a/internal/httpservers/restapi.go
+++ b/internal/httpservers/restapi.go
@@ -75,7 +75,7 @@ func startRestAPIServer(globalConfig *config.Config) error {
 	cfg = globalConfig
 
 	log.WithFields(log.Fields{
-		"address": cfg.ListenAddressGrpcActions,
+		"address": cfg.ListenAddressRestActions,
 	}).Info("Starting REST API")
 
 	mux := newMux()


### PR DESCRIPTION
See #350 