### PR TITLE
feature: pass ot_ args to shellAfterCompleted

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -454,10 +454,10 @@ func (ost *OutputStreamer) String() string {
 	return ost.output.String()
 }
 
-func buildEnv(req *ExecutionRequest) []string {
+func buildEnv(args map[string]string) []string {
 	ret := append(os.Environ(), "OLIVETIN=1")
 
-	for k, v := range req.Arguments {
+	for k, v := range args {
 		varName := fmt.Sprintf("%v", strings.TrimSpace(strings.ToUpper(k)))
 
 		// Skip arguments that might not have a name (eg, confirmation), as this causes weird bugs on Windows.
@@ -480,7 +480,7 @@ func stepExec(req *ExecutionRequest) bool {
 	cmd := wrapCommandInShell(ctx, req.finalParsedCommand)
 	cmd.Stdout = streamer
 	cmd.Stderr = streamer
-	cmd.Env = buildEnv(req)
+	cmd.Env = buildEnv(req.Arguments)
 
 	req.logEntry.ExecutionStarted = true
 
@@ -543,10 +543,7 @@ func stepExecAfter(req *ExecutionRequest) bool {
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
-	fakeRequest := &ExecutionRequest{
-		Arguments: args,
-	}
-	cmd.Env = buildEnv(fakeRequest)
+	cmd.Env = buildEnv(args)
 
 	runerr := cmd.Start()
 

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -518,8 +518,10 @@ func stepExecAfter(req *ExecutionRequest) bool {
 	var stderr bytes.Buffer
 
 	args := map[string]string{
-		"output":   req.logEntry.Output,
-		"exitCode": fmt.Sprintf("%v", req.logEntry.ExitCode),
+		"output":                 req.logEntry.Output,
+		"exitCode":               fmt.Sprintf("%v", req.logEntry.ExitCode),
+		"ot_executionTrackingId": req.TrackingID,
+		"ot_username":            req.AuthenticatedUser.Username,
 	}
 
 	finalParsedCommand, _ := parseActionArguments(req.Action.ShellAfterCompleted, args, req.Action, req.logEntry.ActionTitle, req.EntityPrefix)
@@ -527,6 +529,11 @@ func stepExecAfter(req *ExecutionRequest) bool {
 	cmd := wrapCommandInShell(ctx, finalParsedCommand)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
+
+	fakeRequest := &ExecutionRequest{
+		Arguments: args,
+	}
+	cmd.Env = buildEnv(fakeRequest)
 
 	runerr := cmd.Start()
 


### PR DESCRIPTION
# PR Introduction

rationale: As a user I want to be able to create an apprise message containing a link to the log. In order to do that I need `ot_executionTrackingId`

Tested with an action having 

```yaml
  - title: "Test Notification"
    icon: <iconify-icon icon="fluent:folder-list-16-filled"></iconify-icon>
    popupOnStart: execution-dialog-stdout-only
    shell: "date"
    shellAfterCompleted: 'apprise -vvv -c /config/apprise.yaml -t "Notification: testing" -b "Check the logs at http://localhost:1337/logs/${OT_EXECUTIONTRACKINGID}"'
    maxConcurrent: 1
```

The fakeRequest bits feels hacky, but it seems to work at least

Done partly due to #419 

# Checklist
Please put a X in the boxes as evidence of reading through the checklist.

- [x] I have forked the project, and raised this PR on a feature branch.
- [x] `make githooks` has been run, and my git commit message was accepted by the git hook.
- [ ] `make daemon-compile` runs without any issues. No
```
make daemon-compile
go env -w GOARCH=arm GOARM=6
go: unsupported GOOS/GOARCH pair darwin/arm
make: *** [daemon-compile-armhf] Error 1
```

- [x] `make daemon-codestyle` runs without any issues.
- [x] `make daemon-unittests` runs without any issues.
- [x] `make webui-codestyle` runs without any issues.
- [x] I understand and accept the [AGPL-3.0 license](LICENSE) and [code of conduct](CODE_OF_CONDUCT.md), and my contributions fall under these.
