### PR TITLE
bugfix: Fixed unusual issues that slipped through with shellAfterCompleted 

### DIFF
--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -528,7 +528,14 @@ func stepExecAfter(req *ExecutionRequest) bool {
 		"exitCode": fmt.Sprintf("%v", req.logEntry.ExitCode),
 	}
 
-	finalParsedCommand, _ := parseActionArguments(req.Action.ShellAfterCompleted, args, req.Action, req.logEntry.ActionTitle, req.EntityPrefix)
+	finalParsedCommand, _, err := parseCommandForReplacements(req.Action.ShellAfterCompleted, args)
+
+	if err != nil {
+		msg := "Could not prepare shellAfterCompleted command: " + err.Error() + "\n"
+		req.logEntry.Output += msg
+		log.Warnf(msg)
+		return true
+	}
 
 	cmd := wrapCommandInShell(ctx, finalParsedCommand)
 	cmd.Stdout = &stdout
@@ -538,14 +545,14 @@ func stepExecAfter(req *ExecutionRequest) bool {
 
 	waiterr := cmd.Wait()
 
-	req.logEntry.Output += "\n" + stdout.String()
-	req.logEntry.Output += "OliveTin::shellAfterCompleted stdout\n" + stdout.String()
+	req.logEntry.Output += "\n"
+	req.logEntry.Output += "OliveTin::shellAfterCompleted stdout\n"
 	req.logEntry.Output += stdout.String()
 
-	req.logEntry.Output += "OliveTin::shellAfterCompleted stderr\n" + stdout.String()
+	req.logEntry.Output += "OliveTin::shellAfterCompleted stderr\n"
 	req.logEntry.Output += stderr.String()
 
-	req.logEntry.Output += "OliveTin::shellAfterCompleted errors and summary\n" + stdout.String()
+	req.logEntry.Output += "OliveTin::shellAfterCompleted errors and summary\n"
 	appendErrorToStderr(runerr, req.logEntry)
 	appendErrorToStderr(waiterr, req.logEntry)
 
@@ -555,7 +562,7 @@ func stepExecAfter(req *ExecutionRequest) bool {
 
 	req.logEntry.Output += fmt.Sprintf("Your shellAfterCompleted exited with code %v\n", cmd.ProcessState.ExitCode())
 
-	req.logEntry.Output += "OliveTin::shellAfterCompleted output complete\n" + stdout.String()
+	req.logEntry.Output += "OliveTin::shellAfterCompleted output complete\n"
 
 	return true
 }

--- a/webui.dev/js/marshaller.js
+++ b/webui.dev/js/marshaller.js
@@ -34,12 +34,12 @@ function createAnnotation (key, val) {
 
   domAnnotation.appendChild(createElement('span', {
     innerText: key,
-    classNames: ['annotationKey']
+    classNames: ['annotation-key']
   }))
 
   domAnnotation.appendChild(createElement('span', {
     innerText: val,
-    classNames: ['annotationValue']
+    classNames: ['annotation-value']
   }))
 
   return domAnnotation

--- a/webui.dev/style.css
+++ b/webui.dev/style.css
@@ -472,7 +472,7 @@ span.annotation {
   margin-right: .2em;
 }
 
-span.annotationKey {
+span.annotation-key {
   padding: 0.4em;
   border-radius: 0.4em 0 0 .4em;
   display: inline-block;
@@ -480,7 +480,7 @@ span.annotationKey {
   color: #666;
 }
 
-span.annotationValue {
+span.annotation-value {
   padding: 0.4em;
   border-radius: 0 .4em .4em 0;
   display: inline-block;


### PR DESCRIPTION
#419 #420

So, I can only assume my brain was turned off when I was patching shellAfterCompleted recently.

- The executor `stepExecAfter` call to `parseActionArguments` was silently failing, with an error message of arguments like `output` not being found, and it was returning a empty command to execute (literally ""), which executed "sucessfully". This led to REALLY confusing output.
- I fixed the printing of the error message, and if an error is returned, nothing will be executed for shellAfterCompelted.
- I broke out the parseActionArguments call into a simpler function that skips the type check, which `shellAfterCompleted` can then use. 
- The log messages kept on appending stdout, meaning that once this was fixed, the logs were getting spammed like crazy. It looked really weird. 

Anyway, patched now. 