### PR TITLE
bugfix: Turns out this should now be 403 instead

### DIFF
--- a/webui.dev/main.js
+++ b/webui.dev/main.js
@@ -58,7 +58,7 @@ function fetchGetDashboardComponents () {
   window.fetch(window.restBaseUrl + 'GetDashboardComponents', {
     cors: 'cors'
   }).then(res => {
-    if (!res.ok && res.status === 401) {
+    if (!res.ok && res.status === 403) {
       window.location.href = window.settings.AuthLoginUrl
     }
     return res.json()


### PR DESCRIPTION
# PR Introduction

This is a followup to #347 

Turns out that the backend is now returning 403 and not 401. (I am certain that I saw 401 before, but unclear if I messed up my testing somehow or if possibly #430 changed the error code, anyhow, 403 seems to be correct now anyway)

<img width="967" alt="image" src="https://github.com/user-attachments/assets/5391af11-2e61-46d2-aa87-ef4dde821d74">


# Checklist
Please put a X in the boxes as evidence of reading through the checklist.

- [x] I have forked the project, and raised this PR on a feature branch.
- [x] `make githooks` has been run, and my git commit message was accepted by the git hook.
- [x] `make daemon-compile` runs without any issues.
- [x] `make daemon-codestyle` runs without any issues.
- [x] `make daemon-unittests` runs without any issues.
- [x] `make webui-codestyle` runs without any issues.
- [x] I understand and accept the [AGPL-3.0 license](LICENSE) and [code of conduct](CODE_OF_CONDUCT.md), and my contributions fall under these.
