### PR TITLE
Migrate dashboard-icons to homarr-labs

### DIFF
--- a/var/helper-actions/olivetin-get-dashboard-icons
+++ b/var/helper-actions/olivetin-get-dashboard-icons
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-olivetin-get-git-repo "https://github.com/walkxcode/dashboard-icons.git" /config/custom-webui/dashboard-icons/
+olivetin-get-git-repo "https://github.com/homarr-labs/dashboard-icons.git" /config/custom-webui/dashboard-icons/


### PR DESCRIPTION
Info: https://github.com/homarr-labs/dashboard-icons/discussions/797#discussioncomment-11736264.

_Note: The walkxcode/dashboard-icons repository will continue to function indefinitely but may no longer receive updates._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the source repository for dashboard icons from walkxcode to homarr-labs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->