### PR TITLE
feature: Limit log history to prevent browser lag and grpc encode failures

### DIFF
--- a/OliveTin.proto
+++ b/OliveTin.proto
@@ -102,7 +102,9 @@ message StartActionByGetAndWaitResponse {
 	LogEntry log_entry = 1;
 }
 
-message GetLogsRequest{};
+message GetLogsRequest{
+  int64 start_offset = 1;
+};
 
 message LogEntry {
 	string datetime_started = 1;
@@ -120,10 +122,13 @@ message LogEntry {
 	bool execution_started = 14;
 	bool execution_finished = 15;
 	bool blocked = 16;
+	int64 datetime_index = 17;
 }
 
 message GetLogsResponse {
 	repeated LogEntry logs = 1;
+	int64 count_remaining = 2;
+	int64 page_size = 3;
 }
 
 message ValidateArgumentTypeRequest {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -96,6 +96,7 @@ type Config struct {
 	ExternalRestAddress             string
 	LogLevel                        string
 	LogDebugOptions                 LogDebugOptions
+	LogHistoryPageSize              int64
 	Actions                         []*Action             `mapstructure:"actions"`
 	Entities                        []*EntityFile         `mapstructure:"entities"`
 	Dashboards                      []*DashboardComponent `mapstructure:"dashboards"`
@@ -212,6 +213,7 @@ func DefaultConfigWithBasePort(basePort int) *Config {
 	config.EnableCustomJs = false
 	config.ExternalRestAddress = "."
 	config.LogLevel = "INFO"
+	config.LogHistoryPageSize = 10
 	config.CheckForUpdates = false
 	config.DefaultPermissions.Exec = true
 	config.DefaultPermissions.View = true

--- a/internal/config/config_reloader.go
+++ b/internal/config/config_reloader.go
@@ -44,6 +44,13 @@ func Reload(cfg *Config) {
 		cfg.DefaultPermissions.Logs = false
 	}
 
+	if cfg.LogHistoryPageSize < 10 {
+		log.Warnf("LogsHistoryLimit is too low, setting it to 10")
+		cfg.LogHistoryPageSize = 10
+	} else if cfg.LogHistoryPageSize > 100 {
+		log.Warnf("LogsHistoryLimit is high, you can do this, but expect browser lag.")
+	}
+
 	metricConfigReloadedCount.Inc()
 	metricConfigActionCount.Set(float64(len(cfg.Actions)))
 

--- a/internal/config/config_reloader.go
+++ b/internal/config/config_reloader.go
@@ -36,21 +36,6 @@ func Reload(cfg *Config) {
 		os.Exit(1)
 	}
 
-	if cfg.AuthRequireGuestsToLogin {
-		log.Infof("AuthRequireGuestsToLogin is enabled. All defaultPermissions will be set to false")
-
-		cfg.DefaultPermissions.View = false
-		cfg.DefaultPermissions.Exec = false
-		cfg.DefaultPermissions.Logs = false
-	}
-
-	if cfg.LogHistoryPageSize < 10 {
-		log.Warnf("LogsHistoryLimit is too low, setting it to 10")
-		cfg.LogHistoryPageSize = 10
-	} else if cfg.LogHistoryPageSize > 100 {
-		log.Warnf("LogsHistoryLimit is high, you can do this, but expect browser lag.")
-	}
-
 	metricConfigReloadedCount.Inc()
 	metricConfigActionCount.Set(float64(len(cfg.Actions)))
 

--- a/internal/config/sanitize.go
+++ b/internal/config/sanitize.go
@@ -41,6 +41,28 @@ func (action *Action) sanitize(cfg *Config) {
 	for idx := range action.Arguments {
 		action.Arguments[idx].sanitize()
 	}
+
+	sanitizeAuthRequireGuestsToLogin(cfg)
+	sanitizeLogHistoryPageSize(cfg)
+}
+
+func sanitizeAuthRequireGuestsToLogin(cfg *Config) {
+	if cfg.AuthRequireGuestsToLogin {
+		log.Infof("AuthRequireGuestsToLogin is enabled. All defaultPermissions will be set to false")
+
+		cfg.DefaultPermissions.View = false
+		cfg.DefaultPermissions.Exec = false
+		cfg.DefaultPermissions.Logs = false
+	}
+}
+
+func sanitizeLogHistoryPageSize(cfg *Config) {
+	if cfg.LogHistoryPageSize < 10 {
+		log.Warnf("LogsHistoryLimit is too low, setting it to 10")
+		cfg.LogHistoryPageSize = 10
+	} else if cfg.LogHistoryPageSize > 100 {
+		log.Warnf("LogsHistoryLimit is high, you can do this, but expect browser lag.")
+	}
 }
 
 func getActionID(action *Action) string {

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -138,6 +138,12 @@ func (e *Executor) AddListener(m listener) {
 	e.listeners = append(e.listeners, m)
 }
 
+// getPagingStartIndex calculates the starting index for log pagination.
+// Parameters:
+//   startOffset: The offset from the most recent log (0 means start from the most recent)
+//   totalLogCount: Total number of logs available
+//   count: Number of logs to retrieve
+// Returns: The calculated starting index for pagination
 func getPagingStartIndex(startOffset int64, totalLogCount int64, count int64) int64 {
 	var startIndex int64
 
@@ -145,7 +151,7 @@ func getPagingStartIndex(startOffset int64, totalLogCount int64, count int64) in
 	case startOffset <= 0:
 		startIndex = totalLogCount - 1
 	case startOffset < totalLogCount:
-		startIndex = 0
+		startIndex = totalLogCount - startOffset - 1
 	default:
 		startIndex = totalLogCount - startOffset
 	}

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -16,7 +16,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -172,7 +171,7 @@ func (e *Executor) GetLogTrackingIds(startOffset int64, pageCount int64) ([]*Int
 
 	pageCount = min(totalLogCount, pageCount)
 
-	endIndex := max(0, startIndex-pageCount)
+	endIndex := max(0, (startIndex-pageCount)+1)
 
 	log.WithFields(log.Fields{
 		"startOffset": startOffset,
@@ -182,10 +181,10 @@ func (e *Executor) GetLogTrackingIds(startOffset int64, pageCount int64) ([]*Int
 		"endIndex":    endIndex,
 	}).Infof("GetLogTrackingIds")
 
-	trackingIds := make([]*InternalLogEntry, 0)
+	trackingIds := make([]*InternalLogEntry, 0, pageCount)
 
 	if totalLogCount > 0 {
-		for i := startIndex; i >= endIndex; i-- {
+		for i := endIndex; i <= startIndex; i++ {
 			trackingIds = append(trackingIds, e.logs[e.logsTrackingIdsByDate[i]])
 		}
 	}
@@ -193,8 +192,6 @@ func (e *Executor) GetLogTrackingIds(startOffset int64, pageCount int64) ([]*Int
 	e.logmutex.RUnlock()
 
 	remainingLogs := endIndex
-
-	slices.Reverse(trackingIds)
 
 	return trackingIds, remainingLogs
 }

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -154,19 +154,23 @@ func (e *Executor) GetLogTrackingIds(startOffset int64, count int64) ([]*Interna
 		startIndex = totalLogCount - startOffset
 	}
 
-	count = min(totalLogCount, e.Cfg.LogHistoryPageSize)
+	count = min(totalLogCount, count)
 
 	endIndex := startIndex - count
 
-	log.Infof("GetLogTrackingIds, totalCount: %v, start: %+v, end: %+v, count: %v", totalLogCount, startIndex, endIndex, count)
+	log.WithFields(log.Fields{
+		"startOffset": startOffset,
+		"count":       count,
+		"total":       totalLogCount,
+		"startIndex":  startIndex,
+		"endIndex":    endIndex,
+	}).Tracef("GetLogTrackingIds")
 
 	trackingIds := make([]*InternalLogEntry, count)
 
 	logIndex := count - 1
 
 	for i := startIndex; i > endIndex; i-- {
-		log.Infof("LogIndex: %v, i: %v", logIndex, i)
-
 		trackingIds[logIndex] = e.logs[e.logsTrackingIdsByDate[i]]
 
 		logIndex--
@@ -175,8 +179,6 @@ func (e *Executor) GetLogTrackingIds(startOffset int64, count int64) ([]*Interna
 	e.logmutex.RUnlock()
 
 	remainingLogs := endIndex
-
-	log.Infof("GetLogTrackingIds, count: %v, remaining: %v, logIndex: %v", count, remainingLogs, logIndex)
 
 	return trackingIds, remainingLogs
 }

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -145,11 +145,12 @@ func (e *Executor) GetLogTrackingIds(startOffset int64, count int64) ([]*Interna
 
 	var startIndex int64
 
-	if startOffset == 0 {
+	switch {
+	case startOffset == 0:
 		startIndex = totalLogCount - 1
-	} else if startOffset < totalLogCount {
-		startIndex = 0;
-	} else {
+	case startOffset < totalLogCount:
+		startIndex = 0
+	default:
 		startIndex = totalLogCount - startOffset
 	}
 

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -6,7 +6,6 @@ import (
 
 	acl "github.com/OliveTin/OliveTin/internal/acl"
 	config "github.com/OliveTin/OliveTin/internal/config"
-	log "github.com/sirupsen/logrus"
 )
 
 func testingExecutor() (*Executor, *config.Config) {
@@ -148,8 +147,6 @@ func TestGetLogsLessThanPageSize(t *testing.T) {
 
 	logEntries, remaining = e.GetLogTrackingIds(0, 10)
 
-	log.Infof("logEntries: %v", logEntries)
-
 	assert.Equal(t, 7, len(logEntries), "There should be 7 logs")
 	assert.Zero(t, remaining, "There should be no remaining logs")
 
@@ -161,8 +158,8 @@ func TestGetLogsLessThanPageSize(t *testing.T) {
 
 	logEntries, remaining = e.GetLogTrackingIds(0, 10)
 
-	assert.Equal(t, 11, len(logEntries), "There should be 11 logs")
-	assert.Equal(t, int64(1), remaining, "There should be 1 remaining logs")
+	assert.Equal(t, 10, len(logEntries), "There should be 10 logs")
+	assert.Equal(t, int64(2), remaining, "There should be 1 remaining logs")
 }
 
 func execNewReqAndWait(e *Executor, title string, cfg *config.Config) {
@@ -178,4 +175,7 @@ func execNewReqAndWait(e *Executor, title string, cfg *config.Config) {
 func TestGetPagingIndexes(t *testing.T) {
 	assert.Zero(t, getPagingStartIndex(5, 0, 5), "Testing start index from empty list")
 	assert.Equal(t, int64(4), getPagingStartIndex(5, 10, 5), "Testing start index from mid point")
+	assert.Equal(t, int64(9), getPagingStartIndex(-1, 10, 5), "Testing start index with negative offset")
+	assert.Equal(t, int64(0), getPagingStartIndex(15, 10, 5), "Testing start index with large offset")
+	assert.Equal(t, int64(9), getPagingStartIndex(0, 10, 0), "Testing start index with zero count")
 }

--- a/internal/grpcapi/grpcApi.go
+++ b/internal/grpcapi/grpcApi.go
@@ -335,9 +335,7 @@ func (api *oliveTinAPI) GetLogs(ctx ctx.Context, req *pb.GetLogsRequest) (*pb.Ge
 
 	ret := &pb.GetLogsResponse{}
 
-	// TODO Limit to 10 entries or something to prevent browser lag.
-
-	logEntries, countRemaining := api.executor.GetLogTrackingIds(req.StartOffset, 10)
+	logEntries, countRemaining := api.executor.GetLogTrackingIds(req.StartOffset, cfg.LogHistoryPageSize)
 
 	for _, logEntry := range logEntries {
 		action := cfg.FindAction(logEntry.ActionTitle)

--- a/webui.dev/index.html
+++ b/webui.dev/index.html
@@ -63,7 +63,7 @@
 						</button>
 					</label>
 				</div>
-				<table title = "Logs">
+				<table id = "logsTable" title = "Logs" hidden>
 					<thead>
 						<tr title = "untitled">
 							<th>Timestamp</th>
@@ -74,6 +74,10 @@
 					</thead>
 					<tbody id = "logTableBody" />
 				</table>
+
+				<p id = "logsTableEmpty">There are no logs to display. <a href = "/">Return to index</a></p>
+
+				<p><strong>Note:</strong> The server is configured to only send <strong id = "logs-server-page-size">?</strong> log entries at a time. The search box at the top of this page only searches this current page of logs.</p>
 			</section>
 
 			<section id = "contentDiagnostics" title = "Diagnostics" class = "box-shadow" hidden>

--- a/webui.dev/js/marshaller.js
+++ b/webui.dev/js/marshaller.js
@@ -646,6 +646,19 @@ function marshalDirectory (item, section) {
 }
 
 export function marshalLogsJsonToHtml (json) {
+  // This function is called internally with a "fake" server response, that does 
+  // not have pageSize set. So we need to check if it's set before trying to use it.
+  if (json.pageSize !== undefined) {
+    document.getElementById('logs-server-page-size').innerText = json.pageSize
+  }
+
+  if (json.logs != null && json.logs.length > 0) {
+    document.getElementById('logsTable').hidden = false
+    document.getElementById('logsTableEmpty').hidden = true
+  } else {
+    return
+  }
+
   for (const logEntry of json.logs) {
     let row = document.getElementById('log-' + logEntry.executionTrackingId)
 

--- a/webui.dev/js/marshaller.js
+++ b/webui.dev/js/marshaller.js
@@ -646,7 +646,7 @@ function marshalDirectory (item, section) {
 }
 
 export function marshalLogsJsonToHtml (json) {
-  // This function is called internally with a "fake" server response, that does 
+  // This function is called internally with a "fake" server response, that does
   // not have pageSize set. So we need to check if it's set before trying to use it.
   if (json.pageSize !== undefined) {
     document.getElementById('logs-server-page-size').innerText = json.pageSize


### PR DESCRIPTION
This PR limits log history (by default, to 10 entries, configuration option `logHistoryPageSize: 10`) sent from the server with the API call GetLogs. This prevents browser lag on OliveTin server with lot of logs (eg, my server had 4000!). This has also led to gRPC encoding failures - see #497 . 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced log retrieval with pagination support
	- Added ability to specify log history page size
	- Improved log tracking and indexing mechanism
	- User interface updates to clarify log display and server limitations

- **Documentation**
	- Added user-friendly notes about log retrieval limitations in the web interface

- **Bug Fixes**
	- Implemented more robust log display handling in the web interface
	- Added conditional rendering for empty log scenarios

- **Chores**
	- Improved configuration sanitization for log history page size and guest login settings
<!-- end of auto-generated comment: release notes by coderabbit.ai -->