### PR TITLE
bugfix: Systemd unit now waits for network and filesystem #495

### DIFF
--- a/OliveTin.service
+++ b/OliveTin.service
@@ -1,6 +1,11 @@
 [Unit]
 Description=OliveTin
 
+Requires=network-online.target
+After=network-online.target
+Requires=local-fs.target
+After=local-fs.target
+
 [Service]
 ExecStart=/usr/local/bin/OliveTin
 Restart=always


### PR DESCRIPTION
See #495 . 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved service startup conditions to ensure that required network connectivity and local storage are ready before initiating operations, enhancing overall system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->