### PR TITLE
build(Dockerfile): only install docker cli into containers (no runtime)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,9 @@ RUN mkdir -p /config /config/entities/ /var/www/olivetin \
 		apprise \
 		jq \
 		git \
-		docker \
 	&& microdnf clean all
+
+COPY --from=docker:cli /usr/local/bin/docker /usr/local/bin/docker
 
 RUN useradd --system --create-home olivetin -u 1000
 

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -12,8 +12,9 @@ RUN mkdir -p /config /config/entities/ /var/www/olivetin \
 		apprise \
 		jq \
 		git \
-		docker \
 	&& microdnf clean all
+
+COPY --from=docker:cli /usr/local/bin/docker /usr/local/bin/docker
 
 RUN useradd --system --create-home olivetin -u 1000
 


### PR DESCRIPTION
# Checklist
Please put a X in the boxes as evidence of reading through the checklist.

- [x] I have forked the project, and raised this PR on a feature branch.
- [x] `make githooks` has been run, and my git commit message was accepted by the git hook.
- [x] `make daemon-compile` runs without any issues.
- [x] `make daemon-codestyle` runs without any issues.
- [x] `make daemon-unittests` runs without any issues.
- [x] `make webui-codestyle` runs without any issues.
- [x] I understand and accept the [AGPL-3.0 license](LICENSE) and [code of conduct](CODE_OF_CONDUCT.md), and my contributions fall under these.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the container image build process to ensure the Docker CLI is consistently available.
	- Modified the approach to include the Docker command via a direct binary incorporation rather than a package installation, improving reliability across standard and ARM64 builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->