### PR TITLE
feat: enable JWT auth from a header

### DIFF
--- a/service/internal/config/config.go
+++ b/service/internal/config/config.go
@@ -107,6 +107,7 @@ type Config struct {
 	ShowNewVersions                 bool
 	EnableCustomJs                  bool
 	AuthJwtCookieName               string
+	AuthJwtHeader                   string
 	AuthJwtAud                      string
 	AuthJwtDomain                   string
 	AuthJwtCertsURL                 string

--- a/service/internal/httpservers/restapi.go
+++ b/service/internal/httpservers/restapi.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"net/http"
+	"strings"
 
 	apiv1 "github.com/OliveTin/OliveTin/gen/grpc/olivetin/api/v1"
 
@@ -52,6 +53,12 @@ func parseRequestMetadata(ctx context.Context, req *http.Request) metadata.MD {
 	usergroup := ""
 	provider := "unknown"
 	sid := ""
+
+	if cfg.AuthJwtHeader != "" {
+		// JWTs in the Authorization header are usually prefixed with "Bearer " which is not part of the JWT token.
+		username, usergroup = parseJwt(strings.TrimPrefix(req.Header.Get(cfg.AuthJwtHeader), "Bearer "))
+		provider = "jwt-header"
+	}
 
 	if cfg.AuthJwtCookieName != "" {
 		username, usergroup = parseJwtCookie(req)

--- a/service/internal/httpservers/restapi_auth_jwt.go
+++ b/service/internal/httpservers/restapi_auth_jwt.go
@@ -137,7 +137,11 @@ func parseJwtCookie(request *http.Request) (string, string) {
 		return "", ""
 	}
 
-	claims, err := getClaimsFromJwtToken(cookie.Value)
+	return parseJwt(cookie.Value)
+}
+
+func parseJwt(token string) (string, string) {
+	claims, err := getClaimsFromJwtToken(token)
 
 	if err != nil {
 		log.Warnf("jwt claim error: %+v", err)


### PR DESCRIPTION
# PR Introduction

This allows for JWT auth to be conveyed in a header. I'm planning to put this behind [teleport](https://goteleport.com/docs/enroll-resources/application-access/jwt/introduction/), which can inject a JWT as a header, but doesn't have a facility to do it as a cookie.

# Checklist
Please put a X in the boxes as evidence of reading through the checklist.

- [x] I have forked the project, and raised this PR on a feature branch.
- [ ] I ran the `pre-commit` hooks, and my commit message was validated.
- [x] `make -wC service compile` runs without any issues.
- [x] `make -wC service codestyle` runs without any issues.
- [x] `make -wC service unittests` runs without any issues.
- [x] `make -wC webui codestyle` runs without any issues.
- [ ] `make -w it` runs without any issues.
- [x] I understand and accept the [AGPL-3.0 license](LICENSE) and [code of conduct](CODE_OF_CONDUCT.md), and my contributions fall under these.

Integration tests timed out for me. I'm on a Mac, so maybe there is some setup I'm missing. I did run the service and verify it starts up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced support for processing JWT tokens from a configurable request header, enabling more flexible authentication.

- **Refactor**
  - Streamlined token extraction logic for improved validation and error handling during authentication.
  - Delegated claim parsing to a new function for better organization and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->