### PR TITLE
feat: links to argument forms

### DIFF
--- a/webui.dev/js/ActionButton.js
+++ b/webui.dev/js/ActionButton.js
@@ -45,6 +45,8 @@ class ActionButton extends ExecutionFeedbackButton {
           oldArgumentForm.remove()
         }
 
+        this.updateUrlWithAction()
+
         const frm = document.createElement('argument-form')
         frm.setup(json, (args) => {
           this.startAction(args)
@@ -130,6 +132,17 @@ class ActionButton extends ExecutionFeedbackButton {
     }).catch(err => {
       throw err // We used to flash buttons red, but now hand to the global error handler
     })
+  }
+
+  updateUrlWithAction () {
+    // Get the current URL and create a new URL object
+    const url = new URL(window.location.href)
+
+    // Set the action parameter
+    url.searchParams.set('action', this.btn.title)
+
+    // Update the URL without reloading the page
+    window.history.replaceState({}, '', url.toString())
   }
 
   onActionStarted (executionTrackingId) {

--- a/webui.dev/js/ArgumentForm.js
+++ b/webui.dev/js/ArgumentForm.js
@@ -1,5 +1,9 @@
 
 class ArgumentForm extends window.HTMLElement {
+  getQueryParams () {
+    return new URLSearchParams(window.location.search.substring(1))
+  }
+
   setup (json, callback) {
     this.setAttribute('class', 'action-arguments')
 
@@ -23,6 +27,7 @@ class ArgumentForm extends window.HTMLElement {
     }
 
     this.domBtnCancel.onclick = () => {
+      this.clearBookmark()
       this.remove()
     }
   }
@@ -189,7 +194,19 @@ class ArgumentForm extends window.HTMLElement {
     }
 
     domEl.name = arg.name
-    domEl.value = arg.defaultValue
+
+    // Use query parameter value if available
+    const params = this.getQueryParams()
+    const paramValue = params.get(arg.name)
+
+    if (paramValue !== null) {
+      domEl.value = paramValue
+    } else {
+      domEl.value = arg.defaultValue
+    }
+
+    // update the URL when a parameter is changed
+    domEl.addEventListener('change', this.updateUrlWithArg)
 
     if (typeof arg.suggestions === 'object' && Object.keys(arg.suggestions).length > 0) {
       domEl.setAttribute('list', arg.name + '-choices')
@@ -198,6 +215,20 @@ class ArgumentForm extends window.HTMLElement {
     this.argInputs.push(domEl)
 
     return domEl
+  }
+
+  updateUrlWithArg (ev) {
+    if (!ev.target.name) {
+      return
+    }
+    // Get the current URL and create a new URL object
+    const url = new URL(window.location.href)
+
+    // copy the parameter value
+    url.searchParams.set(ev.target.name, ev.target.value)
+
+    // Update the URL without reloading the page
+    window.history.replaceState({}, '', url.toString())
   }
 
   createDomDescription (arg) {
@@ -215,6 +246,13 @@ class ArgumentForm extends window.HTMLElement {
     domEl.innerText = choice.title
 
     return domEl
+  }
+
+  clearBookmark () {
+    // remove the action from the URL
+    window.history.replaceState({
+      path: window.location.pathname
+    }, '', window.location.pathname)
   }
 }
 


### PR DESCRIPTION
Allows actions that take arguments to be bookmarked/deep-linked, with some or all of the values pre-filled.

Actions that run immediately will not be executed.

# Checklist

Please put a X in the boxes as evidence of reading through the checklist.

- [x] I have read the [CONTRIBUTORS](CONTRIBUTORS.adoc) guide
  - [x] I considered the "3 line" suggestion.
  - [x] I followed the "1 logical change" rule.
- [x] I have forked the project, and raised this PR on a feature branch.
- [ ] I ran the `pre-commit` hooks, and my commit message was validated.
- [ ] `make -wC service compile` runs without any issues.
- [ ] `make -wC service codestyle` runs without any issues.
- [ ] `make -wC service unittests` runs without any issues.
- [ ] `make -wC webui codestyle` runs without any issues.
- [ ] `make -w it` runs without any issues.
- [x] I understand and accept the [AGPL-3.0 license](LICENSE) and [code of conduct](CODE_OF_CONDUCT.md), and my contributions fall under these.


webui codestyle doesn't seem to be a valid make target anymore? 

Didn't run the service checks since this is purely a frontend change. I've run the app locally and verified the feature.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - **Dynamic URL Updates:** User actions now update the browser’s URL instantly—reflecting button interactions and form inputs without a page refresh.
  - **Auto-Triggered Actions:** URL parameters are monitored on page load to automatically trigger corresponding actions, improving navigation continuity and streamlining user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->