### PR TITLE
fix: reloading config after k8s configmap replacement

### DIFF
--- a/service/main.go
+++ b/service/main.go
@@ -121,11 +121,8 @@ func initViperConfig(configDir string) {
 
 	viper.WatchConfig()
 	viper.OnConfigChange(func(e fsnotify.Event) {
-		if e.Op == fsnotify.Write {
-			log.Info("Config file changed:", e.String())
-
-			config.Reload(cfg)
-		}
+		log.Infof("Config file changed: %s", viper.ConfigFileUsed())
+		config.Reload(cfg)
 	})
 
 	config.Reload(cfg)


### PR DESCRIPTION
# PR Introduction

This is a fix for #531. I've been having a similar problem as that issue except I'm using [git-sync](https://github.com/kubernetes/git-sync) to update the config file rather than a ConfigMap. The issue seems to be the same: symlinks. Both these tools use symlinks to aid in updating their data atomically.

## Explanation

Viper's WatchConfig() function [already includes logic](https://github.com/spf13/viper/blob/1508a7ba4478e59a385419023ed91eeeb8d522b4/viper.go#L350-L364) to determine if the config file was changed after the fsnotify event or not. The added filtering for only fsnotify.Write operations was breaking config reloading in cases where the config file is symlinked to elsewhere.

The reason why looking for write events causes us to miss symlink changes is due to how viper detects this case. Viper watches the directory containing the config file and calls filepath.EvalSymlinks to get the true path of the config file after each and every fsnotify event it receives. If the true path has changed since the last event, it updates the true path and calls our listener. This means viper sometimes detects the symlink change while processing some event ahead of the actual modification of the link. In that case, while the callback invocation does represent a real change to the config file, the event passed with it may be some seemingly unrelated operation (like kubernetes writing or chmod-ing the updated target data in the config map mount directory prior to updating the link). Viper passing the event is kind of a footgun in their api because of this.

## Checklist

- [x] I have read the [CONTRIBUTORS](CONTRIBUTORS.adoc) guide
  - [x] I considered the "3 line" suggestion.
  - [x] I followed the "1 logical change" rule.
- [x] I have forked the project, and raised this PR on a feature branch.
- [x] I ran the `pre-commit` hooks, and my commit message was validated.
- [x] `make -wC service compile` runs without any issues.
- [x] `make -wC service codestyle` runs without any issues.
- [x] `make -wC service unittests` runs without any issues.
- [ ] `make -wC webui codestyle` runs without any issues.
- [x] `make -w it` runs without any issues.
- [x] I understand and accept the [AGPL-3.0 license](LICENSE) and [code of conduct](CODE_OF_CONDUCT.md), and my contributions fall under these.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved how configuration file changes are handled. Updates to configuration files are now detected and applied consistently with clearer log messages, ensuring more reliable system behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->