### PR TITLE
feat: support multiple user groups

### DIFF
--- a/service/internal/acl/acl.go
+++ b/service/internal/acl/acl.go
@@ -2,6 +2,7 @@ package acl
 
 import (
 	"context"
+	"strings"
 
 	config "github.com/OliveTin/OliveTin/internal/config"
 	log "github.com/sirupsen/logrus"
@@ -196,18 +197,28 @@ func UserFromSystem(cfg *config.Config, username string) *AuthenticatedUser {
 }
 
 func buildUserAcls(cfg *config.Config, user *AuthenticatedUser) {
+Lists:
 	for _, acl := range cfg.AccessControlLists {
 		if slices.Contains(acl.MatchUsernames, user.Username) {
 			user.Acls = append(user.Acls, acl.Name)
 			continue
 		}
 
-		if slices.Contains(acl.MatchUsergroups, user.Usergroup) {
+		// handle multiple usergroups - groups will be separated by a space
+		if hasGroupsMatch(acl.MatchUsergroups, user.Usergroup) {
 			user.Acls = append(user.Acls, acl.Name)
-			continue
-
+			continue Lists
 		}
 	}
+}
+
+func hasGroupsMatch(matchUsergroups []string, usergroup string) bool {
+	for group := range strings.FieldsSeq(usergroup) {
+		if slices.Contains(matchUsergroups, group) {
+			return true
+		}
+	}
+	return false
 }
 
 func isACLRelevantToAction(cfg *config.Config, actionAcls []string, acl *config.AccessControlList, user *AuthenticatedUser) bool {

--- a/service/internal/acl/acl.go
+++ b/service/internal/acl/acl.go
@@ -213,7 +213,7 @@ Lists:
 }
 
 func hasGroupsMatch(matchUsergroups []string, usergroup string) bool {
-	for group := range strings.FieldsSeq(usergroup) {
+	for _, group := range strings.Fields(usergroup) {
 		if slices.Contains(matchUsergroups, group) {
 			return true
 		}

--- a/service/internal/acl/acl.go
+++ b/service/internal/acl/acl.go
@@ -197,7 +197,6 @@ func UserFromSystem(cfg *config.Config, username string) *AuthenticatedUser {
 }
 
 func buildUserAcls(cfg *config.Config, user *AuthenticatedUser) {
-Lists:
 	for _, acl := range cfg.AccessControlLists {
 		if slices.Contains(acl.MatchUsernames, user.Username) {
 			user.Acls = append(user.Acls, acl.Name)
@@ -207,7 +206,7 @@ Lists:
 		// handle multiple usergroups - groups will be separated by a space
 		if hasGroupsMatch(acl.MatchUsergroups, user.Usergroup) {
 			user.Acls = append(user.Acls, acl.Name)
-			continue Lists
+			continue
 		}
 	}
 }

--- a/service/internal/acl/acl_test.go
+++ b/service/internal/acl/acl_test.go
@@ -1,0 +1,37 @@
+package acl
+
+import "testing"
+
+func Test_hasGroupsMatch(t *testing.T) {
+	tests := []struct {
+		name            string
+		matchUsergroups []string
+		usergroup       string
+		want            bool
+	}{
+		{
+			name:            "No groups match",
+			matchUsergroups: []string{"group1", "group2"},
+			usergroup:       "group3",
+		},
+		{
+			name:            "Exact match",
+			matchUsergroups: []string{"group1", "group2"},
+			usergroup:       "group1",
+			want:            true,
+		},
+		{
+			name:            "Multiple groups match",
+			matchUsergroups: []string{"group1", "group2"},
+			usergroup:       "group1 group2",
+			want:            true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasGroupsMatch(tt.matchUsergroups, tt.usergroup); got != tt.want {
+				t.Errorf("hasGroupsMatch() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/service/internal/httpservers/restapi.go
+++ b/service/internal/httpservers/restapi.go
@@ -55,8 +55,7 @@ func parseRequestMetadata(ctx context.Context, req *http.Request) metadata.MD {
 	sid := ""
 
 	if cfg.AuthJwtHeader != "" {
-		// JWTs in the Authorization header are usually prefixed with "Bearer " which is not part of the JWT token.
-		username, usergroup = parseJwt(strings.TrimPrefix(req.Header.Get(cfg.AuthJwtHeader), "Bearer "))
+		username, usergroup = parseJwtHeader(req)
 		provider = "jwt-header"
 	}
 
@@ -90,6 +89,11 @@ func parseRequestMetadata(ctx context.Context, req *http.Request) metadata.MD {
 	log.Tracef("api request metadata: %+v", md)
 
 	return md
+}
+
+func parseJwtHeader(req *http.Request) (string, string) {
+	// JWTs in the Authorization header are usually prefixed with "Bearer " which is not part of the JWT token.
+	return parseJwt(strings.TrimPrefix(req.Header.Get(cfg.AuthJwtHeader), "Bearer "))
 }
 
 func forwardResponseHandler(ctx context.Context, w http.ResponseWriter, msg protoreflect.ProtoMessage) error {

--- a/service/internal/httpservers/restapi_auth_jwt.go
+++ b/service/internal/httpservers/restapi_auth_jwt.go
@@ -9,6 +9,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"net/http"
 	"os"
+	"strings"
 
 	//	"github.com/coreos/go-oidc/v3/oidc"
 	"github.com/MicahParks/keyfunc/v3"
@@ -153,7 +154,23 @@ func parseJwt(token string) (string, string) {
 	}
 
 	username := lookupClaimValueOrDefault(claims, cfg.AuthJwtClaimUsername, "")
-	usergroup := lookupClaimValueOrDefault(claims, cfg.AuthJwtClaimUserGroup, "")
+	usergroup := parseGroupClaim(cfg.AuthJwtClaimUserGroup, claims)
 
 	return username, usergroup
+}
+
+func parseGroupClaim(groupClaim string, claims jwt.MapClaims) string {
+	usergroup := ""
+	if val, ok := claims[groupClaim]; ok {
+		if array, ok := val.([]interface{}); ok {
+			groups := make([]string, len(array))
+			for i, v := range array {
+				groups[i] = fmt.Sprintf("%s", v)
+			}
+			usergroup = strings.Join(groups, " ")
+		} else {
+			usergroup = fmt.Sprintf("%s", val)
+		}
+	}
+	return usergroup
 }


### PR DESCRIPTION
This is the less disruptive approach to #554, keep using the singular `usergroup` property internally, but convert an array in the JWT to a space separated string. If we encounter such a string when checking an ACL, check each group individually.

# Checklist
Please put a X in the boxes as evidence of reading through the checklist.

- [x] I have read the [CONTRIBUTORS](CONTRIBUTORS.adoc) guide
  - [x] I considered the "3 line" suggestion.
  - [x] I followed the "1 logical change" rule.
- [ ] I have forked the project, and raised this PR on a feature branch.
- [ ] I ran the `pre-commit` hooks, and my commit message was validated.
- [x] `make -wC service compile` runs without any issues.
- [x] `make -wC service codestyle` runs without any issues.
- [x] `make -wC service unittests` runs without any issues.
- [ ] `make -wC webui codestyle` runs without any issues.
- [ ] `make -w it` runs without any issues.
- [x] I understand and accept the [AGPL-3.0 license](LICENSE) and [code of conduct](CODE_OF_CONDUCT.md), and my contributions fall under these.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced user group processing to support multi-group evaluations in access control.
	- Improved JWT claim extraction for robust handling of multi-group tokens.
- **Refactor**
	- Consolidated token header processing to streamline authentication workflows.
- **Tests**
	- Expanded test coverage to validate updated group matching and JWT processing functionality.
	- Added tests for JWT header processing to ensure correct extraction of user information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->