### PR TITLE
Allow OliveTin to use a subpath.

### DIFF
--- a/integration-tests/configs/subpath/config.yaml
+++ b/integration-tests/configs/subpath/config.yaml
@@ -1,0 +1,81 @@
+#
+# Integration Test Config: subpath
+#
+
+listenAddressSingleHTTPFrontend: 0.0.0.0:1337
+
+logLevel: "DEBUG"
+checkForUpdates: false
+
+subPath: /subpath
+
+actions:
+- title: Ping Google.com
+  shell: ping google.com -c 1
+  icon: ping
+
+- title: dir-popup
+  shell: dir
+  popupOnStart: execution-dialog-stdout-only
+
+- title: "{{ server.name }} Wake on Lan"
+  shell: echo "Sending Wake on LAN to {{ server.hostname }}"
+  entity: server
+
+- title: "{{ server.name }} Power Off"
+  shell: "echo 'Power Off Server: {{ server.hostname }}'"
+  entity: server
+
+- title: dashboard action
+  shell: date
+  icon: clock
+
+- title: Ping hypervisor1
+  shell: echo "hypervisor1 online"
+
+- title: Ping hypervisor2
+  shell: echo "hypervisor2 online"
+
+- title: "{{ server.name }} Wake on Lan"
+  shell: echo "Sending Wake on LAN to {{ server.hostname }}"
+  entity: server
+
+- title: "{{ server.name }} Power Off"
+  shell: "echo 'Power Off Server: {{ server.hostname }}'"
+  entity: server
+
+- title: Ping All Servers
+  shell: "echo 'Ping all servers'"
+  icon: ping
+
+entities:
+  - file: entities/servers.yaml
+    name: server
+
+dashboards:
+  - title: My Dashboard
+    contents:
+      - title: dashboard action
+
+  - title: My Servers
+    contents:
+      - title: All Servers
+        type: fieldset
+        contents:
+          - title: Ping All Servers
+          - title: Hypervisors
+            contents:
+              - title: Ping hypervisor1
+              - title: Ping hypervisor2
+
+      - type: fieldset
+        entity: server
+        title: 'Server: {{ server.hostname }}'
+        contents:
+          - type: display
+            title: |
+              Hostname: <strong>{{ server.name }}</strong>
+              IP Address: <strong>{{ server.ip }}</strong>
+
+          - title: '{{ server.name }} Wake on Lan'
+          - title: '{{ server.name }} Power Off'

--- a/integration-tests/configs/subpath/entities/servers.yaml
+++ b/integration-tests/configs/subpath/entities/servers.yaml
@@ -1,0 +1,12 @@
+- name: server1
+  state: started
+  hostname: server1.example.com
+  ip: 192.168.0.1
+- name: server2
+  state: started
+  hostname: server2.example.com
+  ip: 192.168.0.2
+- name: server3
+  state: stopped
+  hostname: server3.example.com
+  ip: 192.168.0.3

--- a/integration-tests/lib/elements.js
+++ b/integration-tests/lib/elements.js
@@ -29,6 +29,10 @@ export function takeScreenshot (webdriver, title) {
 
 export async function getRootAndWait() {
   await webdriver.get(runner.baseUrl())
+  await waitForInitialMarshall()
+}
+
+export async function waitForInitialMarshall() {
   await webdriver.wait(new Condition('wait for initial-marshal-complete', async function() {
     const body = await webdriver.findElement(By.tagName('body'))
     const attr = await body.getAttribute('initial-marshal-complete')

--- a/integration-tests/package-lock.json
+++ b/integration-tests/package-lock.json
@@ -15,7 +15,8 @@
         "chai": "^5.2.0",
         "eslint": "^9.22.0",
         "mocha": "^11.1.0",
-        "selenium-webdriver": "^4.29.0"
+        "selenium-webdriver": "^4.29.0",
+        "yaml": "^2.7.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2354,6 +2355,18 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
+      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
+      "dev": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/yargs": {

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -14,6 +14,7 @@
     "chai": "^5.2.0",
     "eslint": "^9.22.0",
     "mocha": "^11.1.0",
+    "yaml": "^2.7.1",
     "selenium-webdriver": "^4.29.0"
   },
   "dependencies": {

--- a/integration-tests/test/subpath.mjs
+++ b/integration-tests/test/subpath.mjs
@@ -1,0 +1,115 @@
+import { expect } from 'chai'
+import { By, until } from 'selenium-webdriver'
+import {
+  getRootAndWait,
+  waitForInitialMarshall,
+  takeScreenshotOnFailure,
+} from '../lib/elements.js'
+
+
+
+describe('config: subpath', function () {
+  before(async function () {
+    await runner.start('subpath')
+  })
+
+  after(async () => {
+    await runner.stop()
+  })
+
+  afterEach(function () {
+    takeScreenshotOnFailure(this.currentTest, webdriver);
+  });
+
+  it('Page title', async function () {
+    await webdriver.get(runner.baseUrl())
+
+    const title = await webdriver.getTitle()
+    expect(title).to.be.equal("OliveTin")
+  })
+
+  it('Start dir action (popup)', async function () {
+    await getRootAndWait()
+
+    const buttons = await webdriver.findElements(By.css('[title="dir-popup"]'))
+
+    expect(buttons).to.have.length(1)
+
+    const buttonCMD = buttons[0]
+
+    expect(buttonCMD).to.not.be.null
+
+    buttonCMD.click()
+
+    const dialog = await webdriver.findElement(By.id('execution-results-popup'))
+    expect(await dialog.isDisplayed()).to.be.true
+
+    const title = await webdriver.findElement(By.id('execution-dialog-title'))
+    expect(await webdriver.wait(until.elementTextIs(title, 'dir-popup'), 2000)).to.be.exist
+
+    const dialogErr = await webdriver.findElement(By.id('big-error'))
+    expect(dialogErr).to.not.be.null
+    expect(await dialogErr.isDisplayed()).to.be.false
+  })
+
+  it('Load Logs Page', async function () {
+    await webdriver.get(runner.baseUrl() + "/logs")
+    await waitForInitialMarshall()
+
+    const title = await webdriver.getTitle()
+    expect(title).to.be.equal("OliveTin » Logs")
+  })
+
+  it('Load Diagnostics Page', async function () {
+    await webdriver.get(runner.baseUrl() + "/diagnostics")
+    await waitForInitialMarshall()
+
+    const title = await webdriver.getTitle()
+    expect(title).to.be.equal("OliveTin » Diagnostics")
+  })
+  it('Check WebSocket is connected', async function () {
+    await getRootAndWait()
+    const websocketStatus = await webdriver.findElement(By.id('serverConnectionWebSocket'))
+    expect(await webdriver.wait(until.elementTextIs(websocketStatus, "WebSocket"), 2000)).to.be.exist
+    const classAttribute = await websocketStatus.getAttribute("class");
+    if (classAttribute && classAttribute.includes('error')) {
+      throw new Error('Test failed: Element has the undesired class "error".');
+    }
+  })
+  it('Check Rest is connected', async function () {
+    await getRootAndWait()
+    const restStatus = await webdriver.findElement(By.id('serverConnectionRest'))
+    expect(await webdriver.wait(until.elementTextIs(restStatus, "REST"), 2000)).to.be.exist
+    const classAttribute = await restStatus.getAttribute("class");
+    if (classAttribute && classAttribute.includes('error')) {
+      throw new Error('Test failed: Element has the undesired class "error".');
+    }
+  })
+  it('Load MyServers/Hypervisors Page', async function () {
+    await webdriver.get(runner.baseUrl() + "/MyServers/Hypervisors")
+    await waitForInitialMarshall()
+    const buttons = await webdriver.findElements(By.css('[title="Ping hypervisor1"]'))
+
+    expect(buttons).to.have.length(1)
+
+    const buttonCMD = buttons[0]
+
+    expect(buttonCMD).to.not.be.null
+
+    buttonCMD.click()
+  })
+  it('Load Logs Page for successful hypervisor ping', async function () {
+    await webdriver.get(runner.baseUrl() + "/logs")
+    await waitForInitialMarshall()
+
+    const title = await webdriver.getTitle()
+    expect(title).to.be.equal("OliveTin » Logs")
+    const logRows = await webdriver.findElements(By.css('.log-row[title="Ping hypervisor1"]'))
+
+    expect(logRows).to.have.length(1)
+
+    const logRow = logRows[0]
+    let actionStatus = await logRow.findElement(By.css('.action-status'));
+    expect(await webdriver.wait(until.elementTextIs(actionStatus, "Completed"), 2000)).to.be.exist
+  })
+})

--- a/service/internal/config/config.go
+++ b/service/internal/config/config.go
@@ -148,6 +148,10 @@ type Config struct {
 	DefaultIconForBack              string
 	AdditionalNavigationLinks       []*NavigationLink
 
+	// Subpath defines the URL path prefix where the application will be served.
+	// Must start with a forward slash (e.g., "/app") or be empty for root path.
+	Subpath string
+
 	usedConfigDir string
 }
 
@@ -215,6 +219,7 @@ func DefaultConfig() *Config {
 // DefaultConfig gets a new Config structure with sensible default values.
 func DefaultConfigWithBasePort(basePort int) *Config {
 	config := Config{}
+	config.Subpath = "/olyvtin/" // Empty string for root path as default
 	config.UseSingleHTTPFrontend = true
 	config.PageTitle = "OliveTin"
 	config.ShowFooter = true

--- a/service/internal/grpcapi/grpcApi.go
+++ b/service/internal/grpcapi/grpcApi.go
@@ -2,6 +2,7 @@ package grpcapi
 
 import (
 	ctx "context"
+	"net"
 
 	apiv1 "github.com/OliveTin/OliveTin/gen/grpc/olivetin/api/v1"
 	"github.com/google/uuid"
@@ -13,7 +14,6 @@ import (
 	"google.golang.org/grpc/status"
 
 	"errors"
-	"net"
 
 	acl "github.com/OliveTin/OliveTin/internal/acl"
 	config "github.com/OliveTin/OliveTin/internal/config"

--- a/service/internal/httpservers/restapi.go
+++ b/service/internal/httpservers/restapi.go
@@ -122,7 +122,7 @@ func forwardResponseHandlerLogout(md metadata.MD, w http.ResponseWriter) {
 				MaxAge:   31556952, // 1 year
 				Value:    "",
 				HttpOnly: true,
-				Path:     "/",
+				Path:     getCookiePath(),
 			},
 		)
 
@@ -135,7 +135,7 @@ func forwardResponseHandlerLogout(md metadata.MD, w http.ResponseWriter) {
 				MaxAge:   31556952, // 1 year
 				Value:    "",
 				HttpOnly: true,
-				Path:     "/",
+				Path:     getCookiePath(),
 			},
 		)
 

--- a/service/internal/httpservers/restapi_auth_local.go
+++ b/service/internal/httpservers/restapi_auth_local.go
@@ -45,7 +45,7 @@ func forwardResponseHandlerLoginLocalUser(md metadata.MD, w http.ResponseWriter)
 				Value:    sid,
 				MaxAge:   31556952, // 1 year
 				HttpOnly: true,
-				Path:     "/",
+				Path:     getCookiePath(),
 			},
 		)
 	}

--- a/service/internal/httpservers/restapi_auth_oauth2.go
+++ b/service/internal/httpservers/restapi_auth_oauth2.go
@@ -103,7 +103,7 @@ func setOAuthCallbackCookie(w http.ResponseWriter, r *http.Request, name, value 
 		MaxAge:   31556952, // 1 year
 		Secure:   r.TLS != nil,
 		HttpOnly: true,
-		Path:     "/",
+		Path:     getCookiePath(),
 	}
 
 	http.SetCookie(w, cookie)

--- a/service/internal/httpservers/webuiServer_test.go
+++ b/service/internal/httpservers/webuiServer_test.go
@@ -1,18 +1,138 @@
 package httpservers
 
 import (
+	"fmt"
 	config "github.com/OliveTin/OliveTin/internal/config"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"	
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 )
 
 func TestGetWebuiDir(t *testing.T) {
+	originalDir, err := os.Getwd()
+	assert.Equal(t, nil, err)
 	os.Chdir("../../") // go test sets the cwd to "httpservers" by default
+	defer os.Chdir(originalDir)
 
 	cfg = config.DefaultConfig()
 
 	dir := findWebuiDir()
 
 	assert.Equal(t, "../webui/", dir, "Finding the webui dir")
+}
+
+func TestGetBaseUrl(t *testing.T) {
+	originalDir, err := os.Getwd()
+	assert.Equal(t, nil, err)
+	os.Chdir("../../") // go test sets the cwd to "httpservers" by default
+	defer os.Chdir(originalDir)
+	cfg = config.DefaultConfig()
+
+	type testCase struct {
+		TestName            string
+		ExternalRestAddress string
+		Subpath             string
+		expectedBaseUrl     string
+		expectedCookiePath  string
+	}
+
+	testCases := []testCase{
+		{
+			TestName:            "Test default configuration",
+			ExternalRestAddress: ".",
+			Subpath:             "",
+			expectedBaseUrl:     "/",
+			expectedCookiePath:  "/",
+		},
+		{
+			TestName:            "Test where an external rest address is used",
+			ExternalRestAddress: "localhost:1337",
+			Subpath:             "/subpath",
+			expectedBaseUrl:     "localhost:1337/subpath/",
+			expectedCookiePath:  "/subpath",
+		},
+		{
+			TestName:            "Test where an external rest address is used with trailing suffix",
+			ExternalRestAddress: "localhost:1337",
+			Subpath:             "/subpath/",
+			expectedBaseUrl:     "localhost:1337/subpath/",
+			expectedCookiePath:  "/subpath",
+		},
+		{
+			TestName:            "Test where an external rest address is used with trailing suffixes everywhere",
+			ExternalRestAddress: "localhost:1337/",
+			Subpath:             "/subpath/",
+			expectedBaseUrl:     "localhost:1337/subpath/",
+			expectedCookiePath:  "/subpath",
+		},
+		{
+			TestName:            "Test where an external rest address is used with an egregious amount of trailing suffixes",
+			ExternalRestAddress: "localhost:1337/",
+			Subpath:             "///subpath/////",
+			expectedBaseUrl:     "localhost:1337/subpath/",
+			expectedCookiePath:  "/subpath",
+		},
+		{
+			TestName:            "Test with a different port",
+			ExternalRestAddress: "localhost:1300",
+			Subpath:             "/subpath/",
+			expectedBaseUrl:     "localhost:1300/subpath/",
+			expectedCookiePath:  "/subpath",
+		},
+		{
+			TestName:            "Test with a different port and no subpath",
+			ExternalRestAddress: "localhost:1300",
+			Subpath:             "",
+			expectedBaseUrl:     "localhost:1300",
+			expectedCookiePath:  "/",
+		},
+		{
+			TestName:            "Test the default external rest address and a subpath",
+			ExternalRestAddress: ".",
+			Subpath:             "/subpath",
+			expectedBaseUrl:     "/subpath/",
+			expectedCookiePath:  "/subpath",
+		},
+	}
+
+	// Check the default configuration
+	url := baseURL()
+	assert.Equal(t, "/", url)
+
+	for _, testCase := range testCases {
+		t.Run(testCase.TestName, func(t *testing.T) {
+			// Create a temporary copy of the configuration for this test
+			testCfg := *cfg
+			testCfg.ExternalRestAddress = testCase.ExternalRestAddress
+			testCfg.Subpath = testCase.Subpath
+
+			// Store original config and restore after test
+			origCfg := cfg
+			cfg = &testCfg
+			defer func() { cfg = origCfg }()
+
+			url := baseURL()
+			assert.Equal(t, testCase.expectedBaseUrl, url, "Test \"%s\" failed", testCase.TestName)
+
+			rr := httptest.NewRecorder()
+
+			// Confirm that the indexHtml can be re-written to configure the base href
+			serveIndexHtmlWithBasePath(rr)
+
+			if status := rr.Code; status != http.StatusOK {
+				t.Errorf("expected status %v, got %v", http.StatusOK, status)
+			}
+			contentType := rr.Header().Get("content-type")
+			assert.Equal(t, "text/html", contentType)
+			assert.Contains(t, rr.Body.String(), "<title>OliveTin</title>")
+			expectedBaseHref := fmt.Sprintf("<base href=\"%s\">", testCase.expectedBaseUrl)
+			assert.Contains(t, rr.Body.String(), expectedBaseHref)
+
+			path := getCookiePath()
+
+			assert.Equal(t, testCase.expectedCookiePath, path, "Test \"%s\" failed", testCase.TestName)
+		})
+	}
 }

--- a/webui.dev/index.html
+++ b/webui.dev/index.html
@@ -8,8 +8,10 @@
 
 		<title>OliveTin</title>
 
-		<link rel = "stylesheet" type = "text/css" href = "/style.css" />
-		<link rel = "stylesheet" type = "text/css" href = "/theme.css" />
+		<base href = "/" />
+
+		<link rel = "stylesheet" type = "text/css" href = "style.css" />
+		<link rel = "stylesheet" type = "text/css" href = "theme.css" />
 		<link rel = "stylesheet" href = "node_modules/@xterm/xterm/css/xterm.css" />
 
 		<link rel = "shortcut icon" type = "image/png" href = "OliveTinLogo.png" />
@@ -18,7 +20,6 @@
 		<link rel = "apple-touch-icon" sizes="120x120" href="OliveTinLogo-120px.png" />
 		<link rel = "apple-touch-icon" sizes="180x180" href="OliveTinLogo-180px.png" />
 
-		<base href = "/" />
 	</head>
 
 	<body>
@@ -39,8 +40,8 @@
 			</nav>
 
 			<div class = "userinfo">
-				<span id = "link-login" hidden><a href = "/login">Login</a> |</span>
-				<span id = "link-logout" hidden><a href = "/api/Logout">Logout</a> |</span>
+				<span id = "link-login" hidden><a href = "login">Login</a> |</span>
+				<span id = "link-logout" hidden><a href = "api/Logout">Logout</a> |</span>
 				<span id = "username">&nbsp;</span>
 				<svg xmlns="http://www.w3.org/2000/svg" width="1.5em" height="1.5em" viewBox="0 0 24 24"><g fill="none" fill-rule="evenodd"><path d="m12.594 23.258l-.012.002l-.071.035l-.02.004l-.014-.004l-.071-.036q-.016-.004-.024.006l-.004.01l-.017.428l.005.02l.01.013l.104.074l.015.004l.012-.004l.104-.074l.012-.016l.004-.017l-.017-.427q-.004-.016-.016-.018m.264-.113l-.014.002l-.184.093l-.01.01l-.003.011l.018.43l.005.012l.008.008l.201.092q.019.005.029-.008l.004-.014l-.034-.614q-.005-.019-.02-.022m-.715.002a.02.02 0 0 0-.027.006l-.006.014l-.034.614q.001.018.017.024l.015-.002l.201-.093l.01-.008l.003-.011l.018-.43l-.003-.012l-.01-.01z"/><path fill="currentColor" d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10s10-4.477 10-10S17.523 2 12 2M8.5 9.5a3.5 3.5 0 1 1 7 0a3.5 3.5 0 0 1-7 0m9.758 7.484A7.99 7.99 0 0 1 12 20a7.99 7.99 0 0 1-6.258-3.016C7.363 15.821 9.575 15 12 15s4.637.821 6.258 1.984"/></g></svg>
 			</div>
@@ -69,7 +70,7 @@
 					<tbody id = "logTableBody" />
 				</table>
 
-				<p id = "logsTableEmpty">There are no logs to display. <a href = "/">Return to index</a></p>
+				<p id = "logsTableEmpty">There are no logs to display. <a href = ".">Return to index</a></p>
 
 				<p><strong>Note:</strong> The server is configured to only send <strong id = "logs-server-page-size">?</strong> log entries at a time. The search box at the top of this page only searches this current page of logs.</p>
 			</section>

--- a/webui.dev/js/NavigationBar.js
+++ b/webui.dev/js/NavigationBar.js
@@ -7,7 +7,7 @@ export class NavigationBar {
 
 	createLink(title, url, isSupplemental) {
 		const linkA = document.createElement('a')
-		linkA.href = url
+		linkA.href = window.BaseUrl + url
 		linkA.innerText = title
 
 		const navigationLi = document.createElement('li')

--- a/webui.dev/js/marshaller.js
+++ b/webui.dev/js/marshaller.js
@@ -128,9 +128,9 @@ export function marshalDashboardComponentsJsonToHtml (json) {
     marshalActionsJsonToHtml(json)
     marshalDashboardStructureToHtml(json)
 
-	window.navbar.refreshSectionPolicyLinks(json.effectivePolicy)
+    window.navbar.refreshSectionPolicyLinks(json.effectivePolicy)
 
-	refreshDiagnostics(json)
+    refreshDiagnostics(json)
   }
 
   document.body.setAttribute('initial-marshal-complete', 'true')
@@ -254,6 +254,11 @@ function showExecutionResult (pathName) {
 }
 
 function showSection (pathName) {
+  // don't consider the BaseUrl as part of the navigation
+  if (pathName.startsWith(window.BaseUrl)) {
+    pathName = pathName.replace(window.BaseUrl, '')
+  }
+
   if (pathName.startsWith('/logs/')) {
     showExecutionResult(pathName)
     pushNewNavigationPath(pathName)
@@ -295,10 +300,14 @@ function pushNewNavigationPath (pathName) {
   // Get the current query string
   const queryString = window.location.search
 
+  // Ensure proper path concatenation with or without trailing slash in BaseUrl
+  const baseUrl = window.BaseUrl || ''
+  const sanitisedBaseUrl = baseUrl.replace(/\/$/, '') // Ensure we don't get double slashes when concatenating paths
+
   // Push the new state with the path and preserve the query string
   window.history.pushState({
-    path: pathName
-  }, null, pathName + queryString)
+    path: sanitisedBaseUrl + pathName
+  }, null, sanitisedBaseUrl + pathName + queryString)
 }
 
 function setSectionNavigationVisible (visible) {

--- a/webui.dev/js/websocket.js
+++ b/webui.dev/js/websocket.js
@@ -15,7 +15,10 @@ function reconnectWebsocket () {
 
   const websocketConnectionUrl = new URL(window.location.toString())
   websocketConnectionUrl.hash = ''
-  websocketConnectionUrl.pathname = '/websocket'
+
+  const baseUrl = window.BaseUrl || ''
+  const sanitisedBaseUrl = baseUrl.replace(/\/$/, '') // Ensure we don't get double slashes when concatenating paths
+  websocketConnectionUrl.pathname = sanitisedBaseUrl + '/websocket'
 
   if (window.location.protocol === 'https:') {
     websocketConnectionUrl.protocol = 'wss'

--- a/webui.dev/main.js
+++ b/webui.dev/main.js
@@ -5,7 +5,7 @@ import {
   setupSectionNavigation,
   marshalDashboardComponentsJsonToHtml,
   marshalLogsJsonToHtml,
-  refreshServerConnectionLabel,
+  refreshServerConnectionLabel
 } from './js/marshaller.js'
 import { checkWebsocketConnection } from './js/websocket.js'
 
@@ -92,9 +92,15 @@ function fetchGetLogs () {
 }
 
 function processWebuiSettingsJson (settings) {
+  const baseUrl = settings.BaseURL || ''
+  const sanitisedBaseUrl = baseUrl.replace(/\/$/, '') // Ensure we don't get double slashes when concatenating paths
+  window.BaseUrl = sanitisedBaseUrl
+
   setupSectionNavigation(settings.SectionNavigationStyle)
 
-  window.restBaseUrl = settings.Rest
+  // Configure the rest base url for the api endpoints
+  const restBaseUrl = settings.Rest || ''
+  window.restBaseUrl = restBaseUrl
 
   document.querySelector('#currentVersion').innerText = settings.CurrentVersion
 


### PR DESCRIPTION
# PR Introduction

Work on allowing OliveTin to work on a subpath.

Still WIP, not fully tested the docker container on my kubernetes cluster yet.

# Checklist
Please put a X in the boxes as evidence of reading through the checklist.

- [x] I have read the [CONTRIBUTORS](CONTRIBUTORS.adoc) guide
  - [ ] I considered the "3 line" suggestion.
  - [ ] I followed the "1 logical change" rule.
- [x] I have forked the project, and raised this PR on a feature branch.
- [ ] I ran the `pre-commit` hooks, and my commit message was validated.
- [x] `make -wC service compile` runs without any issues.
- [x] `make -wC service codestyle` runs without any issues.
- [x] `make -wC service unittests` runs without any issues.
- [ ] `make -wC webui codestyle` runs without any issues.
- [x] `make -w it` runs without any issues.
- [x] I understand and accept the [AGPL-3.0 license](LICENSE) and [code of conduct](CODE_OF_CONDUCT.md), and my contributions fall under these.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for serving the application under a configurable subpath or base URL, enabling deployment in non-root locations.
  - Updated UI and backend routing to dynamically adjust resource URLs, WebSocket endpoints, and cookie paths based on the configured subpath.
  - Enhanced configuration options to specify subpath and entity-driven dashboards with templated server actions.
  - Added integration tests and sample configurations verifying subpath functionality and entity-driven dashboards.

- **Bug Fixes**
  - Ensured navigation, login/logout, WebSocket connections, and cookie handling work correctly with a configured subpath.

- **Tests**
  - Introduced comprehensive integration tests for subpath deployments, including UI navigation, popup dialogs, backend connectivity, and action completion verification.

- **Documentation**
  - Added example configuration files demonstrating subpath usage and server entity setup.

- **Style**
  - Improved code formatting for better readability in navigation components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->