### PR TITLE
bug: Hide password values in deeplinks #594

### DIFF
--- a/webui.dev/js/ArgumentForm.js
+++ b/webui.dev/js/ArgumentForm.js
@@ -221,8 +221,12 @@ class ArgumentForm extends window.HTMLElement {
     if (!ev.target.name) {
       return
     }
-    // Get the current URL and create a new URL object
+
     const url = new URL(window.location.href)
+
+    if (ev.target.type === 'password') {
+      return;
+    }
 
     // copy the parameter value
     url.searchParams.set(ev.target.name, ev.target.value)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented password input values from being added to the URL, enhancing security and privacy when filling out forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->