### PR TITLE
fix: Datetime mangling for Android phones #564

### DIFF
--- a/service/internal/executor/arguments.go
+++ b/service/internal/executor/arguments.go
@@ -215,10 +215,10 @@ func typeSafetyCheckUrl(value string) error {
 }
 
 func mangleInvalidArgumentValues(req *ExecutionRequest) {
-	mangleIvalidDatetimeValues(req)
+	mangleInvalidDatetimeValues(req)
 }
 
-func mangleIvalidDatetimeValues(req *ExecutionRequest) {
+func mangleInvalidDatetimeValues(req *ExecutionRequest) {
 	for _, arg := range req.Action.Arguments {
 		if arg.Type == "datetime" {
 			value, exists := req.Arguments[arg.Name]
@@ -234,7 +234,7 @@ func mangleIvalidDatetimeValues(req *ExecutionRequest) {
 					"arg":     arg.Name,
 					"value":   value,
 					"actionTitle": req.Action.Title,
-				}).Warnf("Mangled invalid datetime value without seconds to :00 seconds, this is a common issue is commonly caused by Android browsers.")
+				}).Warnf("Mangled invalid datetime value without seconds to :00 seconds, this issue is commonly caused by Android browsers.")
 
 				req.Arguments[arg.Name] = timestamp.Format("2006-01-02T15:04:05")
 			}

--- a/service/internal/executor/arguments.go
+++ b/service/internal/executor/arguments.go
@@ -213,3 +213,32 @@ func typeSafetyCheckUrl(value string) error {
 
 	return err
 }
+
+func mangleInvalidArgumentValues(req *ExecutionRequest) {
+	mangleIvalidDatetimeValues(req)
+}
+
+func mangleIvalidDatetimeValues(req *ExecutionRequest) {
+	for _, arg := range req.Action.Arguments {
+		if arg.Type == "datetime" {
+			value, exists := req.Arguments[arg.Name]
+
+			if !exists || value == "" {
+				continue
+			}
+
+			timestamp, err := time.Parse("2006-01-02T15:04", value)
+
+			if err == nil {
+				log.WithFields(log.Fields {
+					"arg":     arg.Name,
+					"value":   value,
+					"actionTitle": req.Action.Title,
+				}).Warnf("Mangled invalid datetime value without seconds to :00 seconds, this is a common issue is commonly caused by Android browsers.")
+
+				req.Arguments[arg.Name] = timestamp.Format("2006-01-02T15:04:05")
+			}
+
+		}
+	}
+}

--- a/service/internal/executor/executor.go
+++ b/service/internal/executor/executor.go
@@ -402,6 +402,8 @@ func stepParseArgs(req *ExecutionRequest) bool {
 	req.Arguments["ot_executionTrackingId"] = req.TrackingID
 	req.Arguments["ot_username"] = req.AuthenticatedUser.Username
 
+	mangleInvalidArgumentValues(req)
+
 	req.finalParsedCommand, err = parseActionArguments(req.Arguments, req.Action, req.EntityPrefix)
 
 	if err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Datetime arguments missing seconds are now automatically corrected to include ":00" seconds, improving compatibility with certain browsers.
- **Tests**
	- Added a new test to verify that malformed datetime inputs are properly corrected during execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->