### PR TITLE
docs(contributing): update setup instructions for pre-commit

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -35,14 +35,14 @@ The preferred way to communicate is probably via Discord or GitHub issues.
 ```
 # Step1: setup compile env
 # - Fedora
-dnf install git go protobuf-compiler make -y
+dnf install git go protobuf-compiler make pre-commit -y
 # - Windows with chocolatey
-choco install git go protoc make python nodejs-lts -y
+choco install git go protoc make python nodejs-lts -y && pip install pre-commit
 
 # Step2: clone and setup repo
 git clone https://github.com/OliveTin/OliveTin.git
 cd OliveTin
-make githooks
+pre-commit install
 
 # Step3: compile binary for current dev env (OS, ARCH)
 # `make proto` will also run `make go-tools`, which installs "buf". This binary


### PR DESCRIPTION
Update CONTRIBUTING guide to reflect migration from custom git hooks to standard pre-commit framework:

* Add pre-commit package to installation commands for Fedora and Windows
* Replace 'make githooks' with standard 'pre-commit install' command

This completes the migration to pre-commit started in previous refactor commit, ensuring documentation matches current development workflow.

# Checklist
Please put a X in the boxes as evidence of reading through the checklist.

- [X] I have read the [CONTRIBUTORS](CONTRIBUTORS.adoc) guide
  - [X] I considered the "3 line" suggestion.
  - [X] I followed the "1 logical change" rule.
- [X] I have forked the project, and raised this PR on a feature branch.
- [X] I ran the `pre-commit` hooks, and my commit message was validated.
- [X] `make -wC service compile` runs without any issues.
- [X] `make -wC service codestyle` runs without any issues.
- [X] `make -wC service unittests` runs without any issues.
- [X] `make -wC webui codestyle` runs without any issues.
- [X] `make -w it` runs without any issues.
- [X] I understand and accept the [AGPL-3.0 license](LICENSE) and [code of conduct](CODE_OF_CONDUCT.md), and my contributions fall under these.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor setup guide with pre-commit installation for Fedora and Windows platforms. Repository initialization now uses pre-commit instead of previous setup method, providing streamlined and consistent hook management across all development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->