### PR TITLE
fix: Set common security headers by default

### DIFF
--- a/service/internal/config/config.go
+++ b/service/internal/config/config.go
@@ -107,6 +107,15 @@ type PrometheusConfig struct {
 	DefaultGoMetrics bool `koanf:"defaultGoMetrics"`
 }
 
+// SecurityConfig allows users to fine tune the security related HTTP headers.
+type SecurityConfig struct {
+	HeaderContentSecurityPolicy bool   `koanf:"headerContentSecurityPolicy"`
+	ContentSecurityPolicy       string `koanf:"contentSecurityPolicy"`
+	HeaderXContentTypeOptions   bool   `koanf:"headerXContentTypeOptions"`
+	HeaderXFrameOptions         bool   `koanf:"headerXFrameOptions"`
+	XFrameOptions               string `koanf:"xFrameOptions"`
+}
+
 // Config is the global config used through the whole app.
 type Config struct {
 	UseSingleHTTPFrontend           bool                       `koanf:"useSingleHTTPFrontend"`
@@ -160,6 +169,7 @@ type Config struct {
 	InsecureAllowDumpActionMap      bool                       `koanf:"insecureAllowDumpActionMap"`
 	InsecureAllowDumpJwtClaims      bool                       `koanf:"insecureAllowDumpJwtClaims"`
 	Prometheus                      PrometheusConfig           `koanf:"prometheus"`
+	Security                        SecurityConfig             `koanf:"security"`
 	SaveLogs                        SaveLogsConfig             `koanf:"saveLogs"`
 	DefaultIconForActions           string                     `koanf:"defaultIconForActions"`
 	DefaultIconForDirectories       string                     `koanf:"defaultIconForDirectories"`
@@ -268,6 +278,11 @@ func DefaultConfigWithBasePort(basePort int) *Config {
 	config.InsecureAllowDumpJwtClaims = false
 	config.Prometheus.Enabled = false
 	config.Prometheus.DefaultGoMetrics = false
+	config.Security.HeaderContentSecurityPolicy = true
+	config.Security.ContentSecurityPolicy = "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; frame-ancestors 'none'; base-uri 'self'"
+	config.Security.HeaderXContentTypeOptions = true
+	config.Security.HeaderXFrameOptions = true
+	config.Security.XFrameOptions = "DENY"
 	config.DefaultIconForActions = "&#x1F600;"
 	config.DefaultIconForDirectories = "&#128193"
 	config.DefaultIconForBack = "&laquo;"

--- a/service/internal/config/sanitize.go
+++ b/service/internal/config/sanitize.go
@@ -16,6 +16,7 @@ func (cfg *Config) Sanitize() {
 	cfg.sanitizeAuthRequireGuestsToLogin()
 	cfg.sanitizeLogHistoryPageSize()
 	cfg.sanitizeLocalUserPasswords()
+	cfg.sanitizeSecurityHeaders()
 
 	// log.Infof("cfg %p", cfg)
 
@@ -181,6 +182,25 @@ func (cfg *Config) sanitizeLocalUserPasswords() {
 			user.Password = parsePasswordTemplate(user.Password)
 		}
 	}
+}
+
+func (cfg *Config) sanitizeSecurityHeaders() {
+	cfg.sanitizeSecurityHeadersCSP()
+	cfg.sanitizeSecurityHeadersXFrameOptions()
+}
+
+func (cfg *Config) sanitizeSecurityHeadersCSP() {
+	if !cfg.Security.HeaderContentSecurityPolicy || cfg.Security.ContentSecurityPolicy != "" {
+		return
+	}
+	cfg.Security.ContentSecurityPolicy = "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; frame-ancestors 'none'; base-uri 'self'"
+}
+
+func (cfg *Config) sanitizeSecurityHeadersXFrameOptions() {
+	if !cfg.Security.HeaderXFrameOptions || cfg.Security.XFrameOptions != "" {
+		return
+	}
+	cfg.Security.XFrameOptions = "DENY"
 }
 
 // parsePasswordTemplate expands {{ .Env.VAR }} in local user password fields using the process environment.


### PR DESCRIPTION
Common  security headers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated HTTP security headers (Content-Security-Policy, X-Frame-Options, X-Content-Type-Options) with default configurations to enhance application security and protect against common web vulnerabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->