### PR TITLE
Fix typos in themes documentation

### DIFF
--- a/docs/modules/ROOT/pages/reference/reference_themes_for_developers.adoc
+++ b/docs/modules/ROOT/pages/reference/reference_themes_for_developers.adoc
@@ -18,7 +18,7 @@ Note that OliveTin will load `/theme.css` depending on `themeName:` in your conf
 
 == Understanding theme URLs
 
-When you create a theme, OliveTin will serve your theme's CSS at `/theme.css` and any other assets at `/custom-webui/themes/mytheme/`. This might be a little strange at first, as your theme.css file wil be in the `/custom-webui/themes/mytheme/` directory, but OliveTin will still serve it at `/theme.css`. Let's explain why this happens;
+When you create a theme, OliveTin will serve your theme's CSS at `/theme.css` and any other assets at `/custom-webui/themes/mytheme/`. This might be a little strange at first, as your theme.css file will be in the `/custom-webui/themes/mytheme/` directory, but OliveTin will still serve it at `/theme.css`. Let's explain why this happens;
 
 OliveTin wants to make it easy for your reverse proxy, cache server, or browser, to cache as much content as possible. This means that if OliveTin had to inject a new CSS file into the HTML every time you changed your theme, then your reverse proxy, cache server, or browser would have to re-download the HTML every time you changed your theme. This is not ideal. 
 
@@ -26,7 +26,7 @@ It is possible that OliveTin's initial webUiSettings.json (that is loaded to set
 
 To make things fast, OliveTin will copy the content of your `/custom-webui/themes/mytheme/theme.css` file into memory when it starts, and then requests for `/theme.css` will load this file. 
 
-What this means for you, is that to get to files like `backgrond.png` from your CSS, you must write your CSS to point to the file in the `/custom-webui/themes/mytheme/` directory;
+What this means for you, is that to get to files like `background.png` from your CSS, you must write your CSS to point to the file in the `/custom-webui/themes/mytheme/` directory;
 
 .Correct example
 ```
@@ -48,6 +48,4 @@ The OliveTin themes page is here; https://olivetin.app/themes
 
 When you are done with your theme, fork https://github.com/OliveTin/themes on GitHub and create a new page under the "content" directory for your new theme. Commit that to GitHub and then raise a pull request.
 
-If you meed more help, please jump on our discord server! 
-
-
+If you need more help, please jump on our discord server! 

--- a/docs/modules/ROOT/pages/reference/reference_themes_for_developers.adoc
+++ b/docs/modules/ROOT/pages/reference/reference_themes_for_developers.adoc
@@ -48,4 +48,4 @@ The OliveTin themes page is here; https://olivetin.app/themes
 
 When you are done with your theme, fork https://github.com/OliveTin/themes on GitHub and create a new page under the "content" directory for your new theme. Commit that to GitHub and then raise a pull request.
 
-If you need more help, please jump on our discord server! 
+If you need more help, please jump on our Discord server! 


### PR DESCRIPTION
Corrected 3 typos caught in the wild while looking for some documentations

- [x] I have read the [CONTRIBUTORS](CONTRIBUTORS.adoc) guide
  - [x] I considered the "3 line" suggestion. -> I doesn't thinks this need so much talk ?
  - [x] I followed the "1 logical change" rule.
- [x] I have forked the project, and _raised this PR on a feature branch_. next is good ? I don't really understand this point
- [ ] I ran the `pre-commit` hooks, and my commit message was validated.
- [ ] `make -wC service compile` runs without any issues.
- [ ] `make -wC service codestyle` runs without any issues.
- [ ] `make -wC service unittests` runs without any issues.
- [ ] `make -wC webui codestyle` runs without any issues.
- [ ] `make -w it` runs without any issues.
- [x] I understand and accept the [AGPL-3.0 license](LICENSE) and [code of conduct](CODE_OF_CONDUCT.md), and my contributions fall under these.

\* Unchecked checkboxs is due to the fact I simply followed the "Edit page" link on documentation and modified one .md file throught the Github WebUI (who automatically forked for me)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Clarified how theme assets (CSS) are loaded and served at startup for consistent theming.
  * Corrected asset path examples and guidance to avoid confusion when adding custom themes.
  * Fixed typos in theme-related documentation to improve clarity.
  * Updated support/contact guidance for users seeking further assistance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OliveTin/OliveTin/pull/1038?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->