### PR TITLE
chore: install wixl instead of msitools

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -114,9 +114,9 @@ jobs:
             integration-tests
             !integration-tests/node_modules
 
-      - name: Install msitools
+      - name: Install wixl
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
-        run: sudo apt-get update && sudo apt-get install -y msitools
+        run: sudo apt-get update && sudo apt-get install -y wixl
 
       - name: Install goreleaser
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Windows packaging step in the build-and-release pipeline to use a different tool, helping keep release automation current.
  * Preserved the existing behavior that skips this step for pull requests from forks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->