### PR TITLE
Update oauth2_pocketid.adoc scopes

### DIFF
--- a/docs/modules/ROOT/pages/security/oauth2_pocketid.adoc
+++ b/docs/modules/ROOT/pages/security/oauth2_pocketid.adoc
@@ -39,6 +39,7 @@ authOAuth2Providers:
     clientId: "[REDACTED]"
     clientSecret: "[REDACTED]"
     scopes:
+      - openid
       - profile
       - email
     usernameField: preferred_username


### PR DESCRIPTION
PocketID now requires to explicitly include the `openid` scope in the `scopes` list. PocketID will strictly block user information queries with a `403 Forbidden` if this scope is missing.

# Checklist
Please put a X in the boxes as evidence of reading through the checklist.

- [ x] I have read the [CONTRIBUTORS](CONTRIBUTORS.adoc) guide
  - [ x] I considered the "3 line" suggestion.
  - [ x] I followed the "1 logical change" rule.
- [ x] I have forked the project, and raised this PR on a feature branch.
- [ ] I ran the `pre-commit` hooks, and my commit message was validated.
- [ ] `make -wC service compile` runs without any issues.
- [ ] `make -wC service codestyle` runs without any issues.
- [ ] `make -wC service unittests` runs without any issues.
- [ ] `make -wC webui codestyle` runs without any issues.
- [ ] `make -w it` runs without any issues.
- [ x] I understand and accept the [AGPL-3.0 license](LICENSE) and [code of conduct](CODE_OF_CONDUCT.md), and my contributions fall under these.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Pocket ID OAuth2 configuration example to include the required `openid` scope alongside `profile` and `email`.
  * Refreshed the Pocket ID configuration image markup without changing its visible content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->