### PR TITLE
fix: omit display-name field from entity detail and list fields

### DIFF
--- a/frontend/resources/vue/views/EntityDetailsView.vue
+++ b/frontend/resources/vue/views/EntityDetailsView.vue
@@ -40,12 +40,6 @@
             {{ entityType }}
           </router-link>
         </dd>
-        <dt v-if="entityDetails.title">
-          Title
-        </dt>
-        <dd v-if="entityDetails.title">
-          {{ entityDetails.title }}
-        </dd>
         <template v-if="entityDetails.fields">
           <template
             v-for="(value, key) in entityDetails.fields"

--- a/service/internal/api/api.go
+++ b/service/internal/api/api.go
@@ -1733,8 +1733,12 @@ func entityListFields(data any, properties []config.EntityProperty) map[string]s
 		return nil
 	}
 
+	displayFieldKey := entities.DisplayNameFieldKey(data)
 	fields := make(map[string]string, len(properties))
 	for _, property := range properties {
+		if entityFieldIsDisplayName(property.Name, displayFieldKey) {
+			continue
+		}
 		fields[property.Name] = entityPropertyValue(data, property.Name)
 	}
 
@@ -1788,11 +1792,19 @@ func serializeEntityFields(data any) map[string]string {
 		return nil
 	}
 
+	displayFieldKey := entities.DisplayNameFieldKey(data)
 	fields := make(map[string]string)
 	for k, v := range dataMap {
+		if entityFieldIsDisplayName(k, displayFieldKey) {
+			continue
+		}
 		fields[k] = fmt.Sprintf("%v", v)
 	}
 	return fields
+}
+
+func entityFieldIsDisplayName(fieldName, displayFieldKey string) bool {
+	return displayFieldKey != "" && strings.EqualFold(fieldName, displayFieldKey)
 }
 
 func (api *oliveTinAPI) RestartAction(ctx ctx.Context, req *connect.Request[apiv1.RestartActionRequest]) (*connect.Response[apiv1.StartActionResponse], error) {

--- a/service/internal/api/api.go
+++ b/service/internal/api/api.go
@@ -1736,7 +1736,7 @@ func entityListFields(data any, properties []config.EntityProperty) map[string]s
 	displayFieldKey := entities.DisplayNameFieldKey(data)
 	fields := make(map[string]string, len(properties))
 	for _, property := range properties {
-		if entityFieldIsDisplayName(property.Name, displayFieldKey) {
+		if entityPropertyIsDisplayName(property.Name, displayFieldKey) {
 			continue
 		}
 		fields[property.Name] = entityPropertyValue(data, property.Name)
@@ -1792,10 +1792,13 @@ func serializeEntityFields(data any) map[string]string {
 		return nil
 	}
 
-	displayFieldKey := entities.DisplayNameFieldKey(data)
-	fields := make(map[string]string)
+	return serializeEntityFieldsFromMap(dataMap, entities.DisplayNameFieldKey(data))
+}
+
+func serializeEntityFieldsFromMap(dataMap map[string]any, omitFieldKey string) map[string]string {
+	fields := make(map[string]string, len(dataMap))
 	for k, v := range dataMap {
-		if entityFieldIsDisplayName(k, displayFieldKey) {
+		if entityFieldIsSelectedDisplayName(k, omitFieldKey) {
 			continue
 		}
 		fields[k] = fmt.Sprintf("%v", v)
@@ -1803,8 +1806,12 @@ func serializeEntityFields(data any) map[string]string {
 	return fields
 }
 
-func entityFieldIsDisplayName(fieldName, displayFieldKey string) bool {
-	return displayFieldKey != "" && strings.EqualFold(fieldName, displayFieldKey)
+func entityFieldIsSelectedDisplayName(fieldName, displayFieldKey string) bool {
+	return displayFieldKey != "" && fieldName == displayFieldKey
+}
+
+func entityPropertyIsDisplayName(propertyName, displayFieldKey string) bool {
+	return displayFieldKey != "" && strings.EqualFold(propertyName, displayFieldKey)
 }
 
 func (api *oliveTinAPI) RestartAction(ctx ctx.Context, req *connect.Request[apiv1.RestartActionRequest]) (*connect.Response[apiv1.StartActionResponse], error) {

--- a/service/internal/api/api_entities_list_test.go
+++ b/service/internal/api/api_entities_list_test.go
@@ -119,6 +119,76 @@ func findEntityDefinition(definitions []*apiv1.EntityDefinition, title string) *
 	return nil
 }
 
+func TestGetEntityOmitsDisplayNameFieldWhenPropertiesUnset(t *testing.T) {
+	entities.ClearEntitiesOfType("vehicle")
+	entities.AddEntity("vehicle", "0", map[string]any{
+		"title":  "My Car",
+		"status": "parked",
+		"vin":    "123",
+	})
+	t.Cleanup(func() {
+		entities.ClearEntitiesOfType("vehicle")
+	})
+
+	cfg := config.DefaultConfig()
+	cfg.Entities = []*config.EntityFile{{Name: "vehicle"}}
+	cfg.Sanitize()
+
+	ex := executor.DefaultExecutor(cfg)
+	ex.RebuildActionMap()
+	ts, client := getNewTestServerAndClientWithExecutor(cfg, ex)
+	defer ts.Close()
+
+	resp, err := client.GetEntity(context.Background(), connect.NewRequest(&apiv1.GetEntityRequest{
+		Type:      "vehicle",
+		UniqueKey: "0",
+	}))
+	require.NoError(t, err)
+	require.NotNil(t, resp.Msg)
+
+	assert.Equal(t, "My Car", resp.Msg.Title)
+	assert.Equal(t, "parked", resp.Msg.Fields["status"])
+	assert.Equal(t, "123", resp.Msg.Fields["vin"])
+	assert.NotContains(t, resp.Msg.Fields, "title")
+}
+
+func TestGetEntityOmitsDisplayNamePropertyFromConfiguredFields(t *testing.T) {
+	entities.ClearEntitiesOfType("vehicle")
+	entities.AddEntity("vehicle", "0", map[string]any{
+		"title":  "My Car",
+		"status": "parked",
+	})
+	t.Cleanup(func() {
+		entities.ClearEntitiesOfType("vehicle")
+	})
+
+	cfg := config.DefaultConfig()
+	cfg.Entities = []*config.EntityFile{
+		{
+			Name: "vehicle",
+			Properties: []config.EntityProperty{
+				{Name: "title", Title: "Title"},
+				{Name: "status", Title: "Status"},
+			},
+		},
+	}
+	cfg.Sanitize()
+
+	ex := executor.DefaultExecutor(cfg)
+	ex.RebuildActionMap()
+	ts, client := getNewTestServerAndClientWithExecutor(cfg, ex)
+	defer ts.Close()
+
+	resp, err := client.GetEntity(context.Background(), connect.NewRequest(&apiv1.GetEntityRequest{
+		Type:      "vehicle",
+		UniqueKey: "0",
+	}))
+	require.NoError(t, err)
+
+	assert.Equal(t, "parked", resp.Msg.Fields["status"])
+	assert.NotContains(t, resp.Msg.Fields, "title")
+}
+
 func TestGetEntityRestrictsFieldsToConfiguredProperties(t *testing.T) {
 	entities.ClearEntitiesOfType("server")
 	entities.AddEntity("server", "0", map[string]any{

--- a/service/internal/api/api_entities_list_test.go
+++ b/service/internal/api/api_entities_list_test.go
@@ -152,6 +152,38 @@ func TestGetEntityOmitsDisplayNameFieldWhenPropertiesUnset(t *testing.T) {
 	assert.NotContains(t, resp.Msg.Fields, "title")
 }
 
+func TestGetEntityRetainsNonSelectedDisplayNameCasingVariant(t *testing.T) {
+	entities.ClearEntitiesOfType("vehicle")
+	entities.AddEntity("vehicle", "0", map[string]any{
+		"title":  "lower-title-value",
+		"Title":  "upper-title-value",
+		"status": "parked",
+	})
+	t.Cleanup(func() {
+		entities.ClearEntitiesOfType("vehicle")
+	})
+
+	cfg := config.DefaultConfig()
+	cfg.Entities = []*config.EntityFile{{Name: "vehicle"}}
+	cfg.Sanitize()
+
+	ex := executor.DefaultExecutor(cfg)
+	ex.RebuildActionMap()
+	ts, client := getNewTestServerAndClientWithExecutor(cfg, ex)
+	defer ts.Close()
+
+	resp, err := client.GetEntity(context.Background(), connect.NewRequest(&apiv1.GetEntityRequest{
+		Type:      "vehicle",
+		UniqueKey: "0",
+	}))
+	require.NoError(t, err)
+
+	assert.Equal(t, "upper-title-value", resp.Msg.Title)
+	assert.Equal(t, "lower-title-value", resp.Msg.Fields["title"])
+	assert.NotContains(t, resp.Msg.Fields, "Title")
+	assert.Equal(t, "parked", resp.Msg.Fields["status"])
+}
+
 func TestGetEntityOmitsDisplayNamePropertyFromConfiguredFields(t *testing.T) {
 	entities.ClearEntitiesOfType("vehicle")
 	entities.AddEntity("vehicle", "0", map[string]any{

--- a/service/internal/entities/entities_test.go
+++ b/service/internal/entities/entities_test.go
@@ -61,6 +61,23 @@ func TestDisplayNameFieldKey(t *testing.T) {
 	assert.Equal(t, "", DisplayNameFieldKey("not a map"))
 }
 
+func TestDisplayNameFieldKey_caseCollisionIsDeterministic(t *testing.T) {
+	data := map[string]any{
+		"title": "lower",
+		"Title": "upper",
+	}
+
+	assert.Equal(t, "Title", DisplayNameFieldKey(data))
+
+	ClearEntitiesOfType("display_name_collision")
+	defer ClearEntitiesOfType("display_name_collision")
+
+	AddEntity("display_name_collision", "0", data)
+	ordered := GetEntityInstancesOrdered("display_name_collision")
+	require.Len(t, ordered, 1)
+	assert.Equal(t, "upper", ordered[0].Title)
+}
+
 func TestGetEntityInstancesOrdered_emptyOrMissing(t *testing.T) {
 	ordered := GetEntityInstancesOrdered("nonexistent_type")
 	assert.Nil(t, ordered)

--- a/service/internal/entities/entities_test.go
+++ b/service/internal/entities/entities_test.go
@@ -53,6 +53,14 @@ func TestGetEntityInstancesOrdered_lexicographicKeys(t *testing.T) {
 	assert.Equal(t, "zebra", ordered[2].UniqueKey)
 }
 
+func TestDisplayNameFieldKey(t *testing.T) {
+	assert.Equal(t, "title", DisplayNameFieldKey(map[string]any{"title": "Car"}))
+	assert.Equal(t, "name", DisplayNameFieldKey(map[string]any{"name": "Car"}))
+	assert.Equal(t, "Name", DisplayNameFieldKey(map[string]any{"Name": "Car"}))
+	assert.Equal(t, "", DisplayNameFieldKey(map[string]any{"status": "running"}))
+	assert.Equal(t, "", DisplayNameFieldKey("not a map"))
+}
+
 func TestGetEntityInstancesOrdered_emptyOrMissing(t *testing.T) {
 	ordered := GetEntityInstancesOrdered("nonexistent_type")
 	assert.Nil(t, ordered)

--- a/service/internal/entities/storage.go
+++ b/service/internal/entities/storage.go
@@ -126,32 +126,45 @@ func AddEntity(entityName string, entityKey string, data any) {
 
 var entityDisplayNameCandidates = []string{"title", "name", "id", "hostname", "host", "label"}
 
-//gocyclo:ignore
-func entityDisplayNameLookup(data map[string]any) (fieldKey string, value string, found bool) {
+func entityDisplayNameKeysByLower(data map[string]any) map[string]string {
 	keys := make(map[string]string, len(data))
 	for k := range data {
-		keys[strings.ToLower(k)] = k
+		lower := strings.ToLower(k)
+		existing, exists := keys[lower]
+		if exists && k >= existing {
+			continue
+		}
+		keys[lower] = k
+	}
+	return keys
+}
+
+func entityDisplayNameCandidateValue(data map[string]any, keysByLower map[string]string, candidate string) (fieldKey string, value string, ok bool) {
+	lookupKey, exists := keysByLower[strings.ToLower(candidate)]
+	if !exists {
+		return "", "", false
 	}
 
+	rawValue, exists := data[lookupKey]
+	if !exists {
+		return "", "", false
+	}
+
+	valueStr, isString := rawValue.(string)
+	if !isString {
+		return "", "", false
+	}
+
+	return lookupKey, valueStr, true
+}
+
+func entityDisplayNameLookup(data map[string]any) (fieldKey string, value string, found bool) {
+	keysByLower := entityDisplayNameKeysByLower(data)
 	for _, candidate := range entityDisplayNameCandidates {
-		lookupKey, exists := keys[strings.ToLower(candidate)]
-		if !exists {
-			continue
+		if fieldKey, value, ok := entityDisplayNameCandidateValue(data, keysByLower, candidate); ok {
+			return fieldKey, value, true
 		}
-
-		rawValue, ok := data[lookupKey]
-		if !ok {
-			continue
-		}
-
-		valueStr, ok := rawValue.(string)
-		if !ok {
-			continue
-		}
-
-		return lookupKey, valueStr, true
 	}
-
 	return "", "", false
 }
 
@@ -170,7 +183,6 @@ func DisplayNameFieldKey(data any) string {
 	return fieldKey
 }
 
-//gocyclo:ignore
 func findEntityTitle(data any) string {
 	mapData, ok := data.(map[string]any)
 	if !ok {

--- a/service/internal/entities/storage.go
+++ b/service/internal/entities/storage.go
@@ -124,28 +124,65 @@ func AddEntity(entityName string, entityKey string, data any) {
 	rwmutex.Unlock()
 }
 
+var entityDisplayNameCandidates = []string{"title", "name", "id", "hostname", "host", "label"}
+
 //gocyclo:ignore
-func findEntityTitle(data any) string {
-	if mapData, ok := data.(map[string]any); ok {
-		keys := make(map[string]string)
-
-		for k := range mapData {
-			lookupKey := strings.ToLower(k)
-			keys[lookupKey] = k
-		}
-
-		for _, key := range []string{"title", "name", "id", "hostname", "host", "label"} {
-			if lookupKey, exists := keys[strings.ToLower(key)]; exists {
-				if value, ok := mapData[lookupKey]; ok {
-					if valueStr, ok := value.(string); ok {
-						return valueStr
-					}
-				}
-			}
-		}
+func entityDisplayNameLookup(data map[string]any) (fieldKey string, value string, found bool) {
+	keys := make(map[string]string, len(data))
+	for k := range data {
+		keys[strings.ToLower(k)] = k
 	}
 
-	return "Untitled Entity"
+	for _, candidate := range entityDisplayNameCandidates {
+		lookupKey, exists := keys[strings.ToLower(candidate)]
+		if !exists {
+			continue
+		}
+
+		rawValue, ok := data[lookupKey]
+		if !ok {
+			continue
+		}
+
+		valueStr, ok := rawValue.(string)
+		if !ok {
+			continue
+		}
+
+		return lookupKey, valueStr, true
+	}
+
+	return "", "", false
+}
+
+// DisplayNameFieldKey returns the data-file field used as the entity instance title, or "".
+func DisplayNameFieldKey(data any) string {
+	mapData, ok := data.(map[string]any)
+	if !ok {
+		return ""
+	}
+
+	fieldKey, _, found := entityDisplayNameLookup(mapData)
+	if !found {
+		return ""
+	}
+
+	return fieldKey
+}
+
+//gocyclo:ignore
+func findEntityTitle(data any) string {
+	mapData, ok := data.(map[string]any)
+	if !ok {
+		return "Untitled Entity"
+	}
+
+	_, value, found := entityDisplayNameLookup(mapData)
+	if !found {
+		return "Untitled Entity"
+	}
+
+	return value
 }
 
 func ClearEntitiesOfType(entityType string) {


### PR DESCRIPTION
## Summary

- Add `DisplayNameFieldKey` so the API knows which raw field became the instance title.
- Omit that field from `GetEntity` / list `fields` responses (with or without configured `properties`).
- Remove the redundant Title row from the entity details page; the section header already shows the instance name.

Part of #996

## Test plan

- [x] `cd service && go test ./internal/entities/... -run DisplayName`
- [x] `cd service && go test ./internal/api/... -run GetEntityOmits`
- [x] Pre-commit (service + frontend)
- [ ] CI build & release pipeline


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Entity details now display the title once in the section header instead of repeating it among the detail fields.
  - Entity list and detail responses use the configured display name as the response title and omit that exact field from returned details.
  - Display-name handling is now consistent across title and name fields, including case variations, with deterministic results when variants conflict.
  - The “Untitled Entity” fallback remains available when no display name is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->