### PR TITLE
build: make source generation reproducible

### DIFF
--- a/.github/workflows/generated.yml
+++ b/.github/workflows/generated.yml
@@ -1,0 +1,54 @@
+name: Generated source checks
+
+on:
+  push:
+    branches:
+      - main
+      - next
+    paths:
+      - '.github/workflows/generated.yml'
+      - 'Makefile'
+      - 'frontend/resources/scripts/gen/**'
+      - 'lang/**'
+      - 'proto/**'
+      - 'service/gen/**'
+      - 'service/go.mod'
+      - 'service/go.sum'
+      - 'service/Makefile'
+      - 'service/tools.go'
+  pull_request:
+    branches:
+      - next
+    paths:
+      - '.github/workflows/generated.yml'
+      - 'Makefile'
+      - 'frontend/resources/scripts/gen/**'
+      - 'lang/**'
+      - 'proto/**'
+      - 'service/gen/**'
+      - 'service/go.mod'
+      - 'service/go.sum'
+      - 'service/Makefile'
+      - 'service/tools.go'
+
+permissions:
+  contents: read
+
+jobs:
+  generated:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'service/go.mod'
+          cache: true
+          cache-dependency-path: |
+            service/go.sum
+            lang/go.sum
+
+      - name: Check generated sources
+        run: make generated-check

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -46,8 +46,7 @@ pre-commit install
 pre-commit install --hook-type pre-push
 
 # Step3: compile binary for current dev env (OS, ARCH)
-# `make proto` will also run `make go-tools`, which installs "buf". This binary
-# will be put in your GOPATH/bin/, which should be on your path. buf is used to
+# `make proto` installs pinned protobuf tools in GOPATH/bin/ and uses buf to
 # generate the protobuf / Connect RPC stubs.
 make proto
 make

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,10 @@ it:
 go-tools:
 	$(MAKE) -wC service go-tools
 
-proto: go-tools
+proto-tools:
+	$(MAKE) -wC service proto-tools
+
+proto: proto-tools
 	$(MAKE) -wC proto
 
 dist:
@@ -81,4 +84,4 @@ config-tool:
 devcheck:
 	python3 scripts/devcheck.py $(ARGS)
 
-.PHONY: proto default service windows-resources windows-msi frontend-unittests it devcheck
+.PHONY: proto proto-tools default service windows-resources windows-msi frontend-unittests it devcheck

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,12 @@ proto-tools:
 proto: proto-tools
 	$(MAKE) -wC proto
 
+lang-generate:
+	$(MAKE) -wC lang
+
+generated-check: proto lang-generate
+	git diff --exit-code -- service/gen frontend/resources/scripts/gen lang/combined_output.json
+
 dist:
 	echo "dist noop"
 
@@ -84,4 +90,4 @@ config-tool:
 devcheck:
 	python3 scripts/devcheck.py $(ARGS)
 
-.PHONY: proto proto-tools default service windows-resources windows-msi frontend-unittests it devcheck
+.PHONY: proto proto-tools lang-generate generated-check default service windows-resources windows-msi frontend-unittests it devcheck

--- a/lang/main.go
+++ b/lang/main.go
@@ -34,6 +34,7 @@ func main() {
 		log.Fatalf("Error marshalling combined language content: %v", err)
 	}
 
+	jsonData = append(jsonData, '\n')
 	err = os.WriteFile("combined_output.json", jsonData, 0644)
 
 	if err != nil {

--- a/proto/Makefile
+++ b/proto/Makefile
@@ -1,4 +1,5 @@
 buf:
 	buf generate
+	python3 normalize_generated.py
 
 .PHONY: buf

--- a/proto/normalize_generated.py
+++ b/proto/normalize_generated.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+GENERATED_DIRS = (
+    ROOT / "service/gen",
+    ROOT / "frontend/resources/scripts/gen",
+)
+
+
+def normalize_file(path: Path) -> None:
+    content = path.read_bytes()
+    normalized = content.rstrip(b"\r\n") + b"\n"
+
+    if normalized != content:
+        path.write_bytes(normalized)
+
+
+def main() -> None:
+    for directory in GENERATED_DIRS:
+        for path in directory.rglob("*"):
+            if path.is_file():
+                normalize_file(path)
+
+
+if __name__ == "__main__":
+    main()

--- a/service/Makefile
+++ b/service/Makefile
@@ -14,14 +14,10 @@ prep:
 	go generate ./...
 
 compile-armhf:
-	go env -w GOARCH=arm GOARM=6
-	go build -o OliveTin.armhf
-	go env -u GOARCH GOARM
+	GOOS=linux GOARCH=arm GOARM=6 go build -o OliveTin.armhf
 
 compile-x64-lin:
-	go env -w GOOS=linux
-	go build -o OliveTin
-	go env -u GOOS
+	GOOS=linux GOARCH=amd64 go build -o OliveTin
 
 compile-x64-win: windows-resources
 	GOOS=windows GOARCH=amd64 go build -o OliveTin.exe

--- a/service/Makefile
+++ b/service/Makefile
@@ -2,6 +2,10 @@ define delete-files
 	python3 -c "import shutil;shutil.rmtree('$(1)', ignore_errors=True)"
 endef
 
+BUF_VERSION := v1.72.0
+GOLANGCI_LINT_VERSION := v2.13.2
+PROTOC_GEN_GO_VERSION := v1.36.12
+
 compile-currentenv:
 	go build
 
@@ -52,11 +56,12 @@ find-flakey-tests-inf:
 	go run ./scripts/find-flakey-tests-inf
 
 go-tools:
-	go install "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.13.2"
+	go install "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)"
 
-.PHONY: codestyle go-tools unittests unittests-fast find-flakey-tests find-flakey-tests-inf
+proto-tools:
+	go install "github.com/bufbuild/buf/cmd/buf@$(BUF_VERSION)"
+	go install "google.golang.org/protobuf/cmd/protoc-gen-go@$(PROTOC_GEN_GO_VERSION)"
 
-go-tools-all:
-	go install "github.com/bufbuild/buf/cmd/buf"
-	go install "github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.13.2"
-	go install "google.golang.org/protobuf/cmd/protoc-gen-go"
+go-tools-all: go-tools proto-tools
+
+.PHONY: codestyle go-tools proto-tools go-tools-all unittests unittests-fast find-flakey-tests find-flakey-tests-inf

--- a/service/generate.go
+++ b/service/generate.go
@@ -1,3 +1,3 @@
-//go:generate make -wC ../
+//go:generate make -wC ../ proto
 
 package main


### PR DESCRIPTION
## Summary

- pin and provision Buf, protoc-gen-go, and golangci-lint tool versions
- make `make proto` self-contained and narrow `go generate` to protobuf generation
- avoid persistent Go cross-compilation environment changes
- normalize generated files and reject stale protobuf/language output in CI

## Verification

- `make proto-tools` with version checks
- Linux amd64, Linux ARM, and Windows compile targets
- `make generated-check`
- `go generate ./...` followed by a clean generated-source diff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated checks to verify generated sources remain up to date when relevant changes are made.
  - Added commands for generating and validating protocol and language outputs.
  - Added race-enabled unit test support.

- **Documentation**
  - Updated contributor guidance for protocol tool installation and documentation validation.

- **Refactor**
  - Improved generation workflows with pinned tool versions and consistent output formatting.
  - Separated general development tools from protocol-generation tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->