### PR TITLE
fix: authenticate release git pushes with CONTAINER_TOKEN

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -71,6 +71,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: ${{ env.WILL_PUBLISH == 'true' && '0' || '1' }}
+          # Keep the read-only GITHUB_TOKEN out of git config so release uses CONTAINER_TOKEN.
+          persist-credentials: false
 
       - name: Set up QEMU
         if: env.WILL_PUBLISH == 'true'
@@ -167,6 +169,20 @@ jobs:
           MACOS_SIGN_P12: ${{ secrets.MACOS_SIGN_P12 }}
           MACOS_SIGN_PASSWORD: ${{ secrets.MACOS_SIGN_PASSWORD }}
         run: ./var/macos/verify-macos-sign-p12.sh
+
+      - name: Authenticate git for release
+        if: env.WILL_PUBLISH == 'true'
+        env:
+          CONTAINER_TOKEN: ${{ secrets.CONTAINER_TOKEN }}
+        run: |
+          if [[ -z "${CONTAINER_TOKEN}" ]]; then
+            echo "CONTAINER_TOKEN is required for semantic-release git push on main." >&2
+            exit 1
+          fi
+          # Prefer CONTAINER_TOKEN over the workflow's read-only GITHUB_TOKEN for git operations.
+          basic="$(printf 'x-access-token:%s' "${CONTAINER_TOKEN}" | base64 -w 0)"
+          git config --local --unset-all http.https://github.com/.extraheader || true
+          git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic ${basic}"
 
       - name: release
         id: release


### PR DESCRIPTION
## Summary
- keep workflow-level `permissions: contents: read` for PR safety
- set checkout `persist-credentials: false` so the read-only `GITHUB_TOKEN` is not used for git
- before semantic-release on `main`, authenticate git with `CONTAINER_TOKEN`

## Why
Release on merging `next` → `main` failed with `EGITNOPERMISSION` because semantic-release's dry-run push used the checkout-persisted `github-actions[bot]` token after #1120 locked the workflow to `contents: read`.

## Test plan
- [ ] Merge to `next`, then land on `main` (or re-run the release workflow after this reaches `main`)
- [ ] Confirm the `Authenticate git for release` step runs only when `WILL_PUBLISH` is true
- [ ] Confirm PR builds still use read-only workflow permissions and do not publish

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved release automation to use secure authentication during publishing.
  - Added validation to detect missing release credentials before the release process begins.
  - Prevented temporary checkout credentials from being retained in repository configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->