### PR TITLE
fix: cap macOS notarize timeout at Apple's 20m limit

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -224,7 +224,8 @@ notarize:
         key_id: "{{.Env.MACOS_NOTARY_KEY_ID}}"
         key: "{{.Env.MACOS_NOTARY_KEY}}"
         wait: true
-        timeout: 30m
+        # Apple rejects notary auth tokens with lifetimes over 20m.
+        timeout: 20m
 
 release:
   # Publish immediately without Windows assets; sign-windows uploads signed zip/MSI later.


### PR DESCRIPTION
## Summary
- lower `.goreleaser.yml` `notarize.macos.timeout` from `30m` to `20m`

## Why
After the CONTAINER_TOKEN git-auth fix, release reached publish and failed with:

`sign & notarize macOS binaries: timeout must be at most 20m0s, got 30m0s: Apple rejects authentication tokens with longer lifetimes`

## Test plan
- [ ] Merge to `next`, then to `main`
- [ ] Re-run / complete the `3000.20.0` release publish path
- [ ] Confirm goreleaser gets past notarize defaults without the timeout error

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced the macOS notarization timeout from 30 minutes to 20 minutes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->